### PR TITLE
Add custom moveset editing and gameplay with custom movesets

### DIFF
--- a/BattleBump.xcodeproj/project.pbxproj
+++ b/BattleBump.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3F8491FA1EE78AEA000AECF0 /* MPCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8491F91EE78AEA000AECF0 /* MPCManager.swift */; };
 		3FA723DB2534E8DB0035F696 /* CircularCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA723DA2534E8DB0035F696 /* CircularCollectionViewLayout.swift */; };
 		3FA723DF2534EB450035F696 /* CircularCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA723DE2534EB450035F696 /* CircularCollectionViewCell.swift */; };
+		3FA723EA253FC69B0035F696 /* Move.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA723E9253FC69B0035F696 /* Move.swift */; };
 		3FB2EEC01EF0444300C4044C /* Moveset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB2EEBF1EF0444300C4044C /* Moveset.swift */; };
 		3FB2EEC21EF04AA200C4044C /* MovesetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB2EEC11EF04AA200C4044C /* MovesetViewController.swift */; };
 		3FB2EEC41EF04B2B00C4044C /* MovesetEditor.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */; };
@@ -60,6 +61,7 @@
 		3F8491F91EE78AEA000AECF0 /* MPCManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPCManager.swift; sourceTree = "<group>"; };
 		3FA723DA2534E8DB0035F696 /* CircularCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularCollectionViewLayout.swift; sourceTree = "<group>"; };
 		3FA723DE2534EB450035F696 /* CircularCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularCollectionViewCell.swift; sourceTree = "<group>"; };
+		3FA723E9253FC69B0035F696 /* Move.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Move.swift; sourceTree = "<group>"; };
 		3FB2EEBF1EF0444300C4044C /* Moveset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Moveset.swift; sourceTree = "<group>"; };
 		3FB2EEC11EF04AA200C4044C /* MovesetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovesetViewController.swift; sourceTree = "<group>"; };
 		3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MovesetEditor.storyboard; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 				3F8491F91EE78AEA000AECF0 /* MPCManager.swift */,
 				3F59AE062520041B0001D1EA /* AppDelegate.swift */,
 				3FB2EEBF1EF0444300C4044C /* Moveset.swift */,
+				3FA723E9253FC69B0035F696 /* Move.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FA723EA253FC69B0035F696 /* Move.swift in Sources */,
 				3F59AE072520041B0001D1EA /* AppDelegate.swift in Sources */,
 				A25D7B191E6F60A50090BC65 /* Player.swift in Sources */,
 				3F0B629D1EF0F04B006724B7 /* EditVerbsViewController.swift in Sources */,

--- a/BattleBump.xcodeproj/project.pbxproj
+++ b/BattleBump.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		3F8491F61EE761D0000AECF0 /* Home.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F8491F51EE761D0000AECF0 /* Home.storyboard */; };
 		3F8491F81EE77D24000AECF0 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8491F71EE77D24000AECF0 /* HomeViewController.swift */; };
 		3F8491FA1EE78AEA000AECF0 /* MPCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8491F91EE78AEA000AECF0 /* MPCManager.swift */; };
+		3FA723DB2534E8DB0035F696 /* CircularCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA723DA2534E8DB0035F696 /* CircularCollectionViewLayout.swift */; };
+		3FA723DF2534EB450035F696 /* CircularCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA723DE2534EB450035F696 /* CircularCollectionViewCell.swift */; };
 		3FB2EEC01EF0444300C4044C /* Moveset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB2EEBF1EF0444300C4044C /* Moveset.swift */; };
 		3FB2EEC21EF04AA200C4044C /* MovesetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB2EEC11EF04AA200C4044C /* MovesetViewController.swift */; };
 		3FB2EEC41EF04B2B00C4044C /* MovesetEditor.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */; };
@@ -56,6 +58,8 @@
 		3F8491F51EE761D0000AECF0 /* Home.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Home.storyboard; sourceTree = "<group>"; };
 		3F8491F71EE77D24000AECF0 /* HomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		3F8491F91EE78AEA000AECF0 /* MPCManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPCManager.swift; sourceTree = "<group>"; };
+		3FA723DA2534E8DB0035F696 /* CircularCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularCollectionViewLayout.swift; sourceTree = "<group>"; };
+		3FA723DE2534EB450035F696 /* CircularCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularCollectionViewCell.swift; sourceTree = "<group>"; };
 		3FB2EEBF1EF0444300C4044C /* Moveset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Moveset.swift; sourceTree = "<group>"; };
 		3FB2EEC11EF04AA200C4044C /* MovesetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovesetViewController.swift; sourceTree = "<group>"; };
 		3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MovesetEditor.storyboard; sourceTree = "<group>"; };
@@ -157,6 +161,8 @@
 				A2A76BA91E732F450046268D /* BBCheckMark.swift */,
 				3F3956551EE8C33E004F27D7 /* HostCell.swift */,
 				3F725A521F887A95005580D7 /* MovesetCell.swift */,
+				3FA723DA2534E8DB0035F696 /* CircularCollectionViewLayout.swift */,
+				3FA723DE2534EB450035F696 /* CircularCollectionViewCell.swift */,
 			);
 			name = View;
 			sourceTree = "<group>";
@@ -310,6 +316,7 @@
 				3F59AE072520041B0001D1EA /* AppDelegate.swift in Sources */,
 				A25D7B191E6F60A50090BC65 /* Player.swift in Sources */,
 				3F0B629D1EF0F04B006724B7 /* EditVerbsViewController.swift in Sources */,
+				3FA723DB2534E8DB0035F696 /* CircularCollectionViewLayout.swift in Sources */,
 				3F8491FA1EE78AEA000AECF0 /* MPCManager.swift in Sources */,
 				3F3956561EE8C33E004F27D7 /* HostCell.swift in Sources */,
 				A2A76BAA1E732F450046268D /* BBCheckMark.swift in Sources */,
@@ -324,6 +331,7 @@
 				3F3526601E6E4F5E00D84F2C /* UICircularProgressRingDelegate.swift in Sources */,
 				3FE23B491EB57389007DB657 /* GameLogicManager.swift in Sources */,
 				A25D7B1B1E6F60B70090BC65 /* Game.swift in Sources */,
+				3FA723DF2534EB450035F696 /* CircularCollectionViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BattleBump.xcodeproj/project.pbxproj
+++ b/BattleBump.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3FB2EEC21EF04AA200C4044C /* MovesetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB2EEC11EF04AA200C4044C /* MovesetViewController.swift */; };
 		3FB2EEC41EF04B2B00C4044C /* MovesetEditor.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */; };
 		3FE23B491EB57389007DB657 /* GameLogicManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE23B481EB57389007DB657 /* GameLogicManager.swift */; };
+		3FFB7C1A255CC54100B0AA9B /* VerbEditCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFB7C19255CC54100B0AA9B /* VerbEditCell.swift */; };
 		A25D7B191E6F60A50090BC65 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25D7B181E6F60A50090BC65 /* Player.swift */; };
 		A25D7B1B1E6F60B70090BC65 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25D7B1A1E6F60B70090BC65 /* Game.swift */; };
 		A260C3621E6DF1A600F5F84F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A260C3601E6DF1A600F5F84F /* Main.storyboard */; };
@@ -66,6 +67,7 @@
 		3FB2EEC11EF04AA200C4044C /* MovesetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovesetViewController.swift; sourceTree = "<group>"; };
 		3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MovesetEditor.storyboard; sourceTree = "<group>"; };
 		3FE23B481EB57389007DB657 /* GameLogicManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameLogicManager.swift; sourceTree = "<group>"; };
+		3FFB7C19255CC54100B0AA9B /* VerbEditCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerbEditCell.swift; sourceTree = "<group>"; };
 		A25D7B181E6F60A50090BC65 /* Player.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		A25D7B1A1E6F60B70090BC65 /* Game.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
 		A260C3541E6DF1A600F5F84F /* BattleBump.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BattleBump.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -165,6 +167,7 @@
 				3F725A521F887A95005580D7 /* MovesetCell.swift */,
 				3FA723DA2534E8DB0035F696 /* CircularCollectionViewLayout.swift */,
 				3FA723DE2534EB450035F696 /* CircularCollectionViewCell.swift */,
+				3FFB7C19255CC54100B0AA9B /* VerbEditCell.swift */,
 			);
 			name = View;
 			sourceTree = "<group>";
@@ -324,6 +327,7 @@
 				3F8491FA1EE78AEA000AECF0 /* MPCManager.swift in Sources */,
 				3F3956561EE8C33E004F27D7 /* HostCell.swift in Sources */,
 				A2A76BAA1E732F450046268D /* BBCheckMark.swift in Sources */,
+				3FFB7C1A255CC54100B0AA9B /* VerbEditCell.swift in Sources */,
 				3F8491F81EE77D24000AECF0 /* HomeViewController.swift in Sources */,
 				3F725A531F887A95005580D7 /* MovesetCell.swift in Sources */,
 				3FB2EEC21EF04AA200C4044C /* MovesetViewController.swift in Sources */,

--- a/BattleBump.xcodeproj/project.pbxproj
+++ b/BattleBump.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3FB2EEC41EF04B2B00C4044C /* MovesetEditor.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */; };
 		3FE23B491EB57389007DB657 /* GameLogicManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE23B481EB57389007DB657 /* GameLogicManager.swift */; };
 		3FFB7C1A255CC54100B0AA9B /* VerbEditCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFB7C19255CC54100B0AA9B /* VerbEditCell.swift */; };
+		3FFB7C242560DD9A00B0AA9B /* GameMoveCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFB7C232560DD9A00B0AA9B /* GameMoveCell.swift */; };
 		A25D7B191E6F60A50090BC65 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25D7B181E6F60A50090BC65 /* Player.swift */; };
 		A25D7B1B1E6F60B70090BC65 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25D7B1A1E6F60B70090BC65 /* Game.swift */; };
 		A260C3621E6DF1A600F5F84F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A260C3601E6DF1A600F5F84F /* Main.storyboard */; };
@@ -68,6 +69,7 @@
 		3FB2EEC31EF04B2B00C4044C /* MovesetEditor.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MovesetEditor.storyboard; sourceTree = "<group>"; };
 		3FE23B481EB57389007DB657 /* GameLogicManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameLogicManager.swift; sourceTree = "<group>"; };
 		3FFB7C19255CC54100B0AA9B /* VerbEditCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerbEditCell.swift; sourceTree = "<group>"; };
+		3FFB7C232560DD9A00B0AA9B /* GameMoveCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameMoveCell.swift; sourceTree = "<group>"; };
 		A25D7B181E6F60A50090BC65 /* Player.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		A25D7B1A1E6F60B70090BC65 /* Game.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
 		A260C3541E6DF1A600F5F84F /* BattleBump.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BattleBump.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -168,6 +170,7 @@
 				3FA723DA2534E8DB0035F696 /* CircularCollectionViewLayout.swift */,
 				3FA723DE2534EB450035F696 /* CircularCollectionViewCell.swift */,
 				3FFB7C19255CC54100B0AA9B /* VerbEditCell.swift */,
+				3FFB7C232560DD9A00B0AA9B /* GameMoveCell.swift */,
 			);
 			name = View;
 			sourceTree = "<group>";
@@ -321,6 +324,7 @@
 			files = (
 				3FA723EA253FC69B0035F696 /* Move.swift in Sources */,
 				3F59AE072520041B0001D1EA /* AppDelegate.swift in Sources */,
+				3FFB7C242560DD9A00B0AA9B /* GameMoveCell.swift in Sources */,
 				A25D7B191E6F60A50090BC65 /* Player.swift in Sources */,
 				3F0B629D1EF0F04B006724B7 /* EditVerbsViewController.swift in Sources */,
 				3FA723DB2534E8DB0035F696 /* CircularCollectionViewLayout.swift in Sources */,

--- a/BattleBump/CircularCollectionViewCell.swift
+++ b/BattleBump/CircularCollectionViewCell.swift
@@ -1,0 +1,51 @@
+//
+//  CircularCollectionViewCell.swift
+//  BattleBump
+//
+//  Created by Callum Davies on 2020-10-12.
+//  Copyright © 2020 Callum Davies & Dave Augerinos. All rights reserved.
+//
+
+import UIKit
+
+class CircularCollectionViewCell: UICollectionViewCell {
+
+    @IBOutlet weak var circleLabel: UILabel!
+    
+    
+    //    let titleLabel: UILabel
+//
+//    override init(frame: CGRect) {
+//        titleLabel = {
+//            let label = UILabel(frame: .zero)
+//            label.textAlignment = .center
+//            label.textColor = .white
+//            label.translatesAutoresizingMaskIntoConstraints = false
+//            return label
+//        }()
+//        super.init(frame: frame)
+//
+//        backgroundView = {
+//            let view = CircleView(frame: .zero)
+//            view.backgroundColor = .lightGray
+//            return view
+//        }()
+//
+//        contentView.addSubview(titleLabel)
+//        titleLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor, constant: 4.0).isActive = true
+//        titleLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: -4.0).isActive = true
+//        titleLabel.centerYAnchor.constraint(equalTo: contentView.layoutMarginsGuide.centerYAnchor).isActive = true
+//    }
+//
+//    required init?(coder aDecoder: NSCoder) {
+//        super.init()
+//        //        fatalError("init(coder:) has not been implemented")
+//    }
+}
+
+//class CircleView: UICollectionReusableView {
+//    override func layoutSubviews() {
+//        super.layoutSubviews()
+//        layer.cornerRadius = bounds.width / 2.0
+//    }
+//}

--- a/BattleBump/CircularCollectionViewCell.swift
+++ b/BattleBump/CircularCollectionViewCell.swift
@@ -9,43 +9,12 @@
 import UIKit
 
 class CircularCollectionViewCell: UICollectionViewCell {
-
+    
     @IBOutlet weak var circleLabel: UILabel!
     
-    
-    //    let titleLabel: UILabel
-//
-//    override init(frame: CGRect) {
-//        titleLabel = {
-//            let label = UILabel(frame: .zero)
-//            label.textAlignment = .center
-//            label.textColor = .white
-//            label.translatesAutoresizingMaskIntoConstraints = false
-//            return label
-//        }()
-//        super.init(frame: frame)
-//
-//        backgroundView = {
-//            let view = CircleView(frame: .zero)
-//            view.backgroundColor = .lightGray
-//            return view
-//        }()
-//
-//        contentView.addSubview(titleLabel)
-//        titleLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor, constant: 4.0).isActive = true
-//        titleLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: -4.0).isActive = true
-//        titleLabel.centerYAnchor.constraint(equalTo: contentView.layoutMarginsGuide.centerYAnchor).isActive = true
-//    }
-//
-//    required init?(coder aDecoder: NSCoder) {
-//        super.init()
-//        //        fatalError("init(coder:) has not been implemented")
-//    }
+    override var isSelected: Bool {
+        didSet {
+            self.layer.borderWidth = isSelected ? 5 : 1
+        }
+    }
 }
-
-//class CircleView: UICollectionReusableView {
-//    override func layoutSubviews() {
-//        super.layoutSubviews()
-//        layer.cornerRadius = bounds.width / 2.0
-//    }
-//}

--- a/BattleBump/CircularCollectionViewLayout.swift
+++ b/BattleBump/CircularCollectionViewLayout.swift
@@ -1,0 +1,89 @@
+//
+//  CircularCollectionViewLayout.swift
+//  BattleBump
+//
+//  Created by Callum Davies on 2020-10-12.
+//  Copyright © 2020 Callum Davies & Dave Augerinos. All rights reserved.
+//
+
+import UIKit
+
+class CircularCollectionViewLayout: UICollectionViewLayout {
+    
+    // MARK: Getting the Collection View Information
+    
+    override var collectionViewContentSize: CGSize {
+        return collectionView?.bounds.size ?? .zero
+    }
+    
+    // MARK: Invalidating the Layout
+    
+    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        return true
+    }
+    
+    // MARK: Providing Layout Attributes
+    
+    private var layoutCircleFrame = CGRect.zero
+    private let layoutInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+    private let itemSize = CGSize(width: 50, height: 50)
+    private var itemLayoutAttributes = [UICollectionViewLayoutAttributes]()
+    
+    override func prepare() {
+        super.prepare()
+        guard let collectionView = collectionView else { return }
+        itemLayoutAttributes.removeAll()
+        layoutCircleFrame = CGRect(origin: .zero, size: collectionViewContentSize)
+            .inset(by: layoutInsets)
+            .insetBy(dx: itemSize.width / 2.0, dy: itemSize.height / 2.0)
+            .offsetBy(dx: collectionView.contentOffset.x, dy: collectionView.contentOffset.y)
+            .insetBy(dx: -collectionView.contentOffset.x, dy: -collectionView.contentOffset.y)
+        
+        for section in 0..<collectionView.numberOfSections {
+            switch section {
+            case 0:
+                let itemCount = collectionView.numberOfItems(inSection: section)
+                itemLayoutAttributes = (0..<itemCount).map({ (index) -> UICollectionViewLayoutAttributes in
+                    let angleStep: CGFloat = 2.0 * CGFloat.pi / CGFloat(itemCount)
+                    var position = layoutCircleFrame.center
+                    position.x += layoutCircleFrame.size.innerRadius * cos(angleStep * CGFloat(index))
+                    position.y += layoutCircleFrame.size.innerRadius * sin(angleStep * CGFloat(index))
+                    let indexPath = IndexPath(item: index, section: section)
+                    let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+                    attributes.frame = CGRect(center: position, size: itemSize)
+                    return attributes
+                })
+            default:
+                fatalError("Unhandled section \(section).")
+            }
+        }
+    }
+    
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        return itemLayoutAttributes
+    }
+    
+    override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        let numberOfItems = collectionView?.numberOfItems(inSection: indexPath.section) ?? 0
+        guard numberOfItems > 0 else { return nil }
+        switch indexPath.section {
+        case 0:
+            return itemLayoutAttributes[indexPath.item]
+        default:
+            fatalError("Unknown section \(indexPath.section).")
+        }
+    }
+    
+}
+
+extension CGRect {
+    init(center: CGPoint, size: CGSize) {
+        self.init(x: center.x - size.width / 2.0, y: center.y - size.height / 2.0, width: size.width, height: size.height)
+    }
+    
+    var center: CGPoint { return CGPoint(x: midX, y: midY) }
+}
+
+extension CGSize {
+    var innerRadius: CGFloat { return min(width, height) / 2.0 }
+}

--- a/BattleBump/CircularCollectionViewLayout.swift
+++ b/BattleBump/CircularCollectionViewLayout.swift
@@ -91,3 +91,4 @@ class CircularCollectionViewLayout: UICollectionViewLayout {
         attributes?.transform = CGAffineTransform.init(scaleX: 0.01, y: 0.01)
         return attributes
     }
+}

--- a/BattleBump/CircularCollectionViewLayout.swift
+++ b/BattleBump/CircularCollectionViewLayout.swift
@@ -9,81 +9,85 @@
 import UIKit
 
 class CircularCollectionViewLayout: UICollectionViewLayout {
+    // https://github.com/robertmryan/CircularCollectionView/blob/master/CircularCollectionView/CircleLayout.swift
     
-    // MARK: Getting the Collection View Information
-    
-    override var collectionViewContentSize: CGSize {
-        return collectionView?.bounds.size ?? .zero
-    }
-    
-    // MARK: Invalidating the Layout
-    
-    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-        return true
-    }
-    
-    // MARK: Providing Layout Attributes
-    
-    private var layoutCircleFrame = CGRect.zero
-    private let layoutInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
-    private let itemSize = CGSize(width: 50, height: 50)
-    private var itemLayoutAttributes = [UICollectionViewLayoutAttributes]()
+    private var center: CGPoint!
+    private var itemSize: CGSize!
+    private var radius: CGFloat!
+    private var numberOfItems: Int!
     
     override func prepare() {
         super.prepare()
-        guard let collectionView = collectionView else { return }
-        itemLayoutAttributes.removeAll()
-        layoutCircleFrame = CGRect(origin: .zero, size: collectionViewContentSize)
-            .inset(by: layoutInsets)
-            .insetBy(dx: itemSize.width / 2.0, dy: itemSize.height / 2.0)
-            .offsetBy(dx: collectionView.contentOffset.x, dy: collectionView.contentOffset.y)
-            .insetBy(dx: -collectionView.contentOffset.x, dy: -collectionView.contentOffset.y)
         
-        for section in 0..<collectionView.numberOfSections {
-            switch section {
-            case 0:
-                let itemCount = collectionView.numberOfItems(inSection: section)
-                itemLayoutAttributes = (0..<itemCount).map({ (index) -> UICollectionViewLayoutAttributes in
-                    let angleStep: CGFloat = 2.0 * CGFloat.pi / CGFloat(itemCount)
-                    var position = layoutCircleFrame.center
-                    position.x += layoutCircleFrame.size.innerRadius * cos(angleStep * CGFloat(index))
-                    position.y += layoutCircleFrame.size.innerRadius * sin(angleStep * CGFloat(index))
-                    let indexPath = IndexPath(item: index, section: section)
-                    let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
-                    attributes.frame = CGRect(center: position, size: itemSize)
-                    return attributes
-                })
-            default:
-                fatalError("Unhandled section \(section).")
-            }
-        }
+        guard let collectionView = collectionView else { return }
+        
+        center = CGPoint(x: collectionView.bounds.midX, y: collectionView.bounds.midY)
+        let shortestAxisLength = min(collectionView.bounds.width, collectionView.bounds.height)
+        itemSize = CGSize(width: shortestAxisLength * 0.1, height: shortestAxisLength * 0.1)
+        radius = shortestAxisLength * 0.4
+        numberOfItems = collectionView.numberOfItems(inSection: 0)
     }
     
-    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        return itemLayoutAttributes
+    override var collectionViewContentSize: CGSize {
+        return collectionView!.bounds.size
     }
     
     override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        let numberOfItems = collectionView?.numberOfItems(inSection: indexPath.section) ?? 0
-        guard numberOfItems > 0 else { return nil }
-        switch indexPath.section {
-        case 0:
-            return itemLayoutAttributes[indexPath.item]
-        default:
-            fatalError("Unknown section \(indexPath.section).")
+        let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+        
+        let angle = 2 * .pi * CGFloat(indexPath.item) / CGFloat(numberOfItems)
+        
+        attributes.center = CGPoint(x: center.x + radius * cos(angle), y: center.y + radius * sin(angle))
+        attributes.size = itemSize
+        
+        return attributes
+    }
+    
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        return (0 ..< collectionView!.numberOfItems(inSection: 0)).flatMap { item -> UICollectionViewLayoutAttributes? in
+            self.layoutAttributesForItem(at: IndexPath(item: item, section: 0))
         }
     }
     
-}
-
-extension CGRect {
-    init(center: CGPoint, size: CGSize) {
-        self.init(x: center.x - size.width / 2.0, y: center.y - size.height / 2.0, width: size.width, height: size.height)
+    // MARK: - Handle insertion and deletion animation
+    
+//    private var inserted: [IndexPath]?
+//    private var deleted: [IndexPath]?
+    
+    override func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
+        super.prepare(forCollectionViewUpdates: updateItems)
+        
+//        inserted = updateItems
+//            .filter { $0.updateAction == .insert }
+//            .flatMap { $0.indexPathAfterUpdate }
+//        deleted = updateItems
+//            .filter { $0.updateAction == .delete }
+//            .flatMap { $0.indexPathBeforeUpdate }
     }
     
-    var center: CGPoint { return CGPoint(x: midX, y: midY) }
-}
-
-extension CGSize {
-    var innerRadius: CGFloat { return min(width, height) / 2.0 }
-}
+    override func finalizeCollectionViewUpdates() {
+        super.finalizeCollectionViewUpdates()
+        
+//        inserted = nil
+//        deleted = nil
+    }
+    
+    override func initialLayoutAttributesForAppearingItem(at itemIndexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        var attributes = super.initialLayoutAttributesForAppearingItem(at: itemIndexPath)
+//        guard inserted!.contains(itemIndexPath) else { return attributes }
+        
+        attributes = layoutAttributesForItem(at: itemIndexPath)
+        attributes?.center = CGPoint(x: collectionView!.bounds.midX, y: collectionView!.bounds.midY)
+        attributes?.alpha = 0
+        return attributes
+    }
+    
+    override func finalLayoutAttributesForDisappearingItem(at itemIndexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        var attributes = super.finalLayoutAttributesForDisappearingItem(at: itemIndexPath)
+//        guard deleted!.contains(itemIndexPath) else { return attributes }
+        
+        attributes = layoutAttributesForItem(at: itemIndexPath)
+        attributes?.center = CGPoint(x: collectionView!.bounds.midX, y: collectionView!.bounds.midY)
+        attributes?.transform = CGAffineTransform.init(scaleX: 0.01, y: 0.01)
+        return attributes
+    }

--- a/BattleBump/CircularCollectionViewLayout.swift
+++ b/BattleBump/CircularCollectionViewLayout.swift
@@ -23,7 +23,7 @@ class CircularCollectionViewLayout: UICollectionViewLayout {
         
         center = CGPoint(x: collectionView.bounds.midX, y: collectionView.bounds.midY)
         let shortestAxisLength = min(collectionView.bounds.width, collectionView.bounds.height)
-        itemSize = CGSize(width: shortestAxisLength * 0.1, height: shortestAxisLength * 0.1)
+        itemSize = CGSize(width: shortestAxisLength * 0.15, height: shortestAxisLength * 0.15)
         radius = shortestAxisLength * 0.4
         numberOfItems = collectionView.numberOfItems(inSection: 0)
     }

--- a/BattleBump/EditVerbsViewController.swift
+++ b/BattleBump/EditVerbsViewController.swift
@@ -46,30 +46,33 @@ class EditVerbsViewController: UIViewController, UITableViewDataSource, UITableV
         print("Current section move: \(sectionMove)")
         let sectionMoveIndex = movesetInProgress.moveArray.firstIndex(where: { $0.moveName == sectionMove.moveName })
         let losingMove = movesetInProgress.moveArray[wrapping: sectionMoveIndex! - (indexPath.row+1)]
-        //        cell.move = losingMove
-        //        cell.verbTextField.text = sectionMove.moveVerbs[losingMove.moveName]
         cell.verbTextField.delegate = self
         
         let winningVerb = sectionMove.moveVerbs[losingMove.moveName]
-        cell.configure(losingMoveName: losingMove.moveName, verb: winningVerb!)
+        cell.configure(losingMove: losingMove, verb: winningVerb!)
         return cell
     }
     
-    @IBAction func verbTextFieldDidEndEditing(_ sender: UITextField) {
-        
-        guard let text = sender.text, !text.isEmpty else {
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let text = textField.text, !text.isEmpty else {
             return
         }
-        
-        if let cell = sender.superview as? VerbEditCell {
+
+        if let cell = textField.superview?.superview as? VerbEditCell {
             if let senderPath = verbsTableView.indexPath(for: cell) {
                 print("\(senderPath)")
-                movesetInProgress.moveArray[senderPath.section].moveVerbs[cell.losingMoveLabel.text!] = sender.text
+                movesetInProgress.moveArray[senderPath.section].moveVerbs[cell.cellMove!.moveName] = textField.text
             }
-            
         }
         verbsTableView.reloadData()
-        sender.resignFirstResponder()
+        textField.resignFirstResponder()
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+//        textField.resignFirstResponder()
+//        return true
+        self.view.endEditing(true)
+        return false
     }
     
 }

--- a/BattleBump/EditVerbsViewController.swift
+++ b/BattleBump/EditVerbsViewController.swift
@@ -9,35 +9,40 @@
 import UIKit
 
 class EditVerbsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
-
-  @IBOutlet weak var verbsTableView: UITableView!
-  
-  
-  //MARK: - IBActions -
-  
-  @IBAction func doneButtonPressed(_ sender: UIBarButtonItem) {
     
-  }
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    @IBOutlet weak var verbsTableView: UITableView!
     
-    // Do any additional setup after loading the view.
-  }
-
-  //MARK: - Tableview methods -
-  
-  func numberOfSections(in tableView: UITableView) -> Int {
-    return 0
-  }
-  
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 0
-  }
-  
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = UITableViewCell()
-    return cell
-  }
-  
+    var movesetInProgress: Moveset!
+    var onFinishEditingVerbs: ((Moveset) -> Void)?
+    
+    //MARK: - IBActions -
+    
+    @IBAction func doneButtonPressed(_ sender: UIBarButtonItem) {
+        self.onFinishEditingVerbs?(self.movesetInProgress)
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    //MARK: - Tableview methods -
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return movesetInProgress.moveArray.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return Int(round(Double(movesetInProgress.moveArray.count/2)))
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return "[\(movesetInProgress.moveArray[section].moveName)/\(movesetInProgress.moveArray[section].moveEmoji)]"
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell()
+        return cell
+    }
+    
 }

--- a/BattleBump/EditVerbsViewController.swift
+++ b/BattleBump/EditVerbsViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class EditVerbsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+class EditVerbsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UITextFieldDelegate {
     
     @IBOutlet weak var verbsTableView: UITableView!
     
@@ -37,11 +37,15 @@ class EditVerbsViewController: UIViewController, UITableViewDataSource, UITableV
     }
     
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return "[\(movesetInProgress.moveArray[section].moveName)/\(movesetInProgress.moveArray[section].moveEmoji)]"
+        return "\(movesetInProgress.moveArray[section].moveEmoji) \(movesetInProgress.moveArray[section].moveName)"
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell()
+        let cell = tableView.dequeueReusableCell(withIdentifier: "verbCell", for: indexPath) as! VerbEditCell
+        let sectionMove = movesetInProgress.moveArray[indexPath.section]
+        print("Current section move: \(sectionMove)")
+        let sectionMoveIndex = movesetInProgress.moveArray.firstIndex(where: { $0.moveName == sectionMove.moveName })
+        cell.move = movesetInProgress.moveArray[wrapping: sectionMoveIndex! - (indexPath.row+1)]
         return cell
     }
     

--- a/BattleBump/EditVerbsViewController.swift
+++ b/BattleBump/EditVerbsViewController.swift
@@ -45,8 +45,31 @@ class EditVerbsViewController: UIViewController, UITableViewDataSource, UITableV
         let sectionMove = movesetInProgress.moveArray[indexPath.section]
         print("Current section move: \(sectionMove)")
         let sectionMoveIndex = movesetInProgress.moveArray.firstIndex(where: { $0.moveName == sectionMove.moveName })
-        cell.move = movesetInProgress.moveArray[wrapping: sectionMoveIndex! - (indexPath.row+1)]
+        let losingMove = movesetInProgress.moveArray[wrapping: sectionMoveIndex! - (indexPath.row+1)]
+        //        cell.move = losingMove
+        //        cell.verbTextField.text = sectionMove.moveVerbs[losingMove.moveName]
+        cell.verbTextField.delegate = self
+        
+        let winningVerb = sectionMove.moveVerbs[losingMove.moveName]
+        cell.configure(losingMoveName: losingMove.moveName, verb: winningVerb!)
         return cell
+    }
+    
+    @IBAction func verbTextFieldDidEndEditing(_ sender: UITextField) {
+        
+        guard let text = sender.text, !text.isEmpty else {
+            return
+        }
+        
+        if let cell = sender.superview as? VerbEditCell {
+            if let senderPath = verbsTableView.indexPath(for: cell) {
+                print("\(senderPath)")
+                movesetInProgress.moveArray[senderPath.section].moveVerbs[cell.losingMoveLabel.text!] = sender.text
+            }
+            
+        }
+        verbsTableView.reloadData()
+        sender.resignFirstResponder()
     }
     
 }

--- a/BattleBump/Game.storyboard
+++ b/BattleBump/Game.storyboard
@@ -2,7 +2,9 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IQO-lq-MNe">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,67 +26,19 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="👊🏽" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Wz-ga-G3k">
-                                <rect key="frame" x="81.5" y="577" width="60" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="5CF-mO-uOE"/>
-                                    <constraint firstAttribute="width" constant="60" id="sJz-CW-n6a"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✋🏽" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pSi-K7-M4f">
-                                <rect key="frame" x="157.5" y="577" width="60" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="ptY-Pq-grq"/>
-                                    <constraint firstAttribute="width" constant="60" id="wOx-ei-Uuf"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✌🏽" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="miJ-z8-sPv">
-                                <rect key="frame" x="231.5" y="577" width="60" height="60"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="60" id="8KU-HE-gib"/>
-                                    <constraint firstAttribute="width" constant="60" id="cJM-Da-3nN"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Paper" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pKu-Nj-S2B">
-                                <rect key="frame" x="167.5" y="558" width="40" height="18"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="0.29803922770000002" green="0.29803922770000002" blue="0.29803922770000002" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rock" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mbj-5r-0Jk">
-                                <rect key="frame" x="94" y="558" width="35" height="18"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="0.29803922770000002" green="0.29803922770000002" blue="0.29803922770000002" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scissors" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ve5-yi-xT9">
-                                <rect key="frame" x="232.5" y="558" width="58" height="18"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="0.29803922770000002" green="0.29803922770000002" blue="0.29803922770000002" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CxO-Tv-Ruy">
-                                <rect key="frame" x="162" y="466" width="51" height="30"/>
+                                <rect key="frame" x="162" y="368.5" width="51" height="30"/>
                                 <state key="normal" title="Ready?"/>
                                 <connections>
                                     <action selector="readyButtonPressed:" destination="IQO-lq-MNe" eventType="touchUpInside" id="pQ2-Px-0gZ"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yFo-fR-xpo" customClass="UICircularProgressRingView" customModule="BattleBump" customModuleProvider="target">
-                                <rect key="frame" x="62.5" y="208.5" width="250" height="250"/>
+                                <rect key="frame" x="87.5" y="152.5" width="200" height="200"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="250" id="aZN-4f-oJi"/>
-                                    <constraint firstAttribute="width" constant="250" id="zpf-g2-3Fe"/>
+                                    <constraint firstAttribute="height" constant="200" id="aZN-4f-oJi"/>
+                                    <constraint firstAttribute="width" constant="200" id="zpf-g2-3Fe"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="maxValue">
@@ -111,9 +65,12 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vme-i4-HFv">
-                                <rect key="frame" x="52" y="197" width="270" height="270"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vme-i4-HFv">
+                                <rect key="frame" x="87.5" y="152.5" width="200" height="200"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="200" id="I2l-PU-Bfe"/>
+                                    <constraint firstAttribute="height" constant="200" id="ubt-Po-sJc"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="175"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -124,57 +81,107 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="RESULT" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4nv-IM-y4q">
-                                <rect key="frame" x="16" y="129" width="343" height="47"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RESULT" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4nv-IM-y4q">
+                                <rect key="frame" x="138" y="103" width="99" height="33.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qbH-vN-kdo">
-                                <rect key="frame" x="16" y="86" width="343" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="winsAndRoundsLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qbH-vN-kdo">
+                                <rect key="frame" x="105.5" y="66" width="164" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="sCy-Wb-fUW">
+                                <rect key="frame" x="8" y="414.5" width="359" height="75"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="75" id="fvO-E0-swi"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="AEQ-r8-2xQ">
+                                    <size key="itemSize" width="65" height="65"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="gameMove" id="f1O-4P-c66" customClass="GameMoveCell" customModule="BattleBump" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="75" height="75"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="acz-we-2DQ">
+                                            <rect key="frame" x="0.0" y="0.0" width="75" height="75"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveEmoji" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JAR-k2-i50">
+                                                    <rect key="frame" x="0.0" y="0.0" width="75" height="45"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveName" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oUt-iF-Q9L">
+                                                    <rect key="frame" x="0.0" y="45" width="75" height="30"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="oUt-iF-Q9L" secondAttribute="bottom" id="2am-tc-a9e"/>
+                                                <constraint firstItem="JAR-k2-i50" firstAttribute="centerX" secondItem="acz-we-2DQ" secondAttribute="centerX" id="FvC-9V-wKb"/>
+                                                <constraint firstItem="oUt-iF-Q9L" firstAttribute="height" secondItem="acz-we-2DQ" secondAttribute="height" multiplier="0.4" id="WeK-nB-n4h"/>
+                                                <constraint firstItem="JAR-k2-i50" firstAttribute="width" secondItem="acz-we-2DQ" secondAttribute="width" id="XPA-vT-tma"/>
+                                                <constraint firstItem="JAR-k2-i50" firstAttribute="height" secondItem="acz-we-2DQ" secondAttribute="height" multiplier="0.6" id="beq-Wp-fS8"/>
+                                                <constraint firstItem="JAR-k2-i50" firstAttribute="top" secondItem="acz-we-2DQ" secondAttribute="top" id="mvb-03-rhm"/>
+                                                <constraint firstItem="oUt-iF-Q9L" firstAttribute="centerX" secondItem="acz-we-2DQ" secondAttribute="centerX" id="wBE-yX-jZR"/>
+                                                <constraint firstItem="oUt-iF-Q9L" firstAttribute="width" secondItem="acz-we-2DQ" secondAttribute="width" id="yZO-0L-cjv"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="75" height="75"/>
+                                        <connections>
+                                            <outlet property="moveEmojiLabel" destination="JAR-k2-i50" id="HCL-3D-O8w"/>
+                                            <outlet property="moveNameLabel" destination="oUt-iF-Q9L" id="uPg-6K-M4W"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <connections>
+                                    <outlet property="dataSource" destination="IQO-lq-MNe" id="Ygh-DS-W4K"/>
+                                    <outlet property="delegate" destination="IQO-lq-MNe" id="XQx-vs-q4h"/>
+                                </connections>
+                            </collectionView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="3Wz-ga-G3k" firstAttribute="top" secondItem="Mbj-5r-0Jk" secondAttribute="bottom" constant="1" id="0IJ-Wz-XGI"/>
-                            <constraint firstItem="Mbj-5r-0Jk" firstAttribute="centerX" secondItem="3Wz-ga-G3k" secondAttribute="centerX" id="1at-9K-o2N"/>
                             <constraint firstItem="9QW-rL-RJG" firstAttribute="leading" secondItem="tYc-lm-cpa" secondAttribute="leadingMargin" id="3EM-2Q-oEz"/>
+                            <constraint firstItem="4nv-IM-y4q" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="3vQ-6a-uJe"/>
+                            <constraint firstItem="vme-i4-HFv" firstAttribute="top" secondItem="4nv-IM-y4q" secondAttribute="bottom" constant="16" id="7Xd-Ju-3z9"/>
+                            <constraint firstItem="vme-i4-HFv" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="8Fm-6p-hdZ"/>
                             <constraint firstItem="61y-Ok-IF2" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="9QX-od-Yuk"/>
-                            <constraint firstItem="pKu-Nj-S2B" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="BFS-zc-mO7"/>
-                            <constraint firstItem="RMQ-iU-oe5" firstAttribute="top" secondItem="miJ-z8-sPv" secondAttribute="bottom" constant="30" id="CCX-kS-NfH"/>
-                            <constraint firstItem="miJ-z8-sPv" firstAttribute="leading" secondItem="pSi-K7-M4f" secondAttribute="trailing" constant="14" id="Fmm-9U-Xnl"/>
-                            <constraint firstItem="miJ-z8-sPv" firstAttribute="top" secondItem="ve5-yi-xT9" secondAttribute="bottom" constant="1" id="IzP-uz-S7c"/>
-                            <constraint firstItem="pSi-K7-M4f" firstAttribute="top" secondItem="pKu-Nj-S2B" secondAttribute="bottom" constant="1" id="KuB-ct-Q3M"/>
-                            <constraint firstItem="RMQ-iU-oe5" firstAttribute="top" secondItem="pSi-K7-M4f" secondAttribute="bottom" constant="30" id="NZ1-tH-PkR"/>
+                            <constraint firstItem="sCy-Wb-fUW" firstAttribute="leading" secondItem="tYc-lm-cpa" secondAttribute="leading" constant="8" id="Dgx-Kx-N7x"/>
+                            <constraint firstItem="qbH-vN-kdo" firstAttribute="top" secondItem="61y-Ok-IF2" secondAttribute="bottom" constant="8" id="KVe-Vv-GqK"/>
+                            <constraint firstItem="qbH-vN-kdo" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="Lvv-Jr-VCV"/>
+                            <constraint firstItem="CxO-Tv-Ruy" firstAttribute="top" secondItem="yFo-fR-xpo" secondAttribute="bottom" constant="16" id="MQM-mU-dZp"/>
+                            <constraint firstAttribute="trailing" secondItem="sCy-Wb-fUW" secondAttribute="trailing" constant="8" id="NFW-4b-f2m"/>
                             <constraint firstItem="9QW-rL-RJG" firstAttribute="trailing" secondItem="tYc-lm-cpa" secondAttribute="trailingMargin" id="QkB-95-gIy"/>
-                            <constraint firstItem="ve5-yi-xT9" firstAttribute="top" secondItem="CxO-Tv-Ruy" secondAttribute="bottom" constant="62" id="TtD-F7-fst"/>
+                            <constraint firstItem="sCy-Wb-fUW" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="SeC-lC-5mM"/>
                             <constraint firstItem="CxO-Tv-Ruy" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="UNd-lv-L72"/>
-                            <constraint firstItem="ve5-yi-xT9" firstAttribute="centerX" secondItem="miJ-z8-sPv" secondAttribute="centerX" id="UWl-Et-h8p"/>
                             <constraint firstItem="yFo-fR-xpo" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="Vi6-96-CBH"/>
+                            <constraint firstItem="yFo-fR-xpo" firstAttribute="top" secondItem="4nv-IM-y4q" secondAttribute="bottom" constant="16" id="X62-sn-Mo9"/>
                             <constraint firstItem="61y-Ok-IF2" firstAttribute="trailing" secondItem="tYc-lm-cpa" secondAttribute="trailingMargin" id="XpH-te-fMi"/>
-                            <constraint firstItem="pSi-K7-M4f" firstAttribute="centerX" secondItem="tYc-lm-cpa" secondAttribute="centerX" id="aco-VQ-GiD"/>
+                            <constraint firstItem="4nv-IM-y4q" firstAttribute="top" secondItem="qbH-vN-kdo" secondAttribute="bottom" constant="16" id="ZuH-7o-Scg"/>
                             <constraint firstItem="61y-Ok-IF2" firstAttribute="top" secondItem="9QW-rL-RJG" secondAttribute="bottom" constant="8" id="fRg-i2-cSf"/>
                             <constraint firstItem="61y-Ok-IF2" firstAttribute="leading" secondItem="tYc-lm-cpa" secondAttribute="leadingMargin" id="hfg-Fx-gfz"/>
-                            <constraint firstItem="pSi-K7-M4f" firstAttribute="leading" secondItem="3Wz-ga-G3k" secondAttribute="trailing" constant="16" id="oen-f8-nwU"/>
-                            <constraint firstItem="RMQ-iU-oe5" firstAttribute="top" secondItem="3Wz-ga-G3k" secondAttribute="bottom" constant="30" id="pnb-c6-X0F"/>
+                            <constraint firstItem="sCy-Wb-fUW" firstAttribute="top" secondItem="CxO-Tv-Ruy" secondAttribute="bottom" constant="16" id="m1L-Y0-My3"/>
                             <constraint firstItem="9QW-rL-RJG" firstAttribute="top" secondItem="Hv7-zb-vUh" secondAttribute="bottom" constant="8" id="vzo-Lc-g1O"/>
-                            <constraint firstItem="yFo-fR-xpo" firstAttribute="centerY" secondItem="tYc-lm-cpa" secondAttribute="centerY" id="wcj-fR-qOF"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="currentPlayGameLabel" destination="9QW-rL-RJG" id="mO4-Rq-xhs"/>
+                        <outlet property="gameMovesCollectionView" destination="sCy-Wb-fUW" id="pn7-Z3-jNN"/>
                         <outlet property="giantMoveLabel" destination="vme-i4-HFv" id="ssU-bS-6Sx"/>
-                        <outlet property="paperLabel" destination="pSi-K7-M4f" id="4aQ-iE-Pst"/>
                         <outlet property="progressRing" destination="yFo-fR-xpo" id="bTg-pz-gBR"/>
                         <outlet property="readyButton" destination="CxO-Tv-Ruy" id="8Pa-NG-nN0"/>
                         <outlet property="resultLabel" destination="4nv-IM-y4q" id="AAG-d3-GuV"/>
-                        <outlet property="rockLabel" destination="3Wz-ga-G3k" id="40o-3q-5az"/>
-                        <outlet property="scissorsLabel" destination="miJ-z8-sPv" id="vcu-az-eVi"/>
                         <outlet property="theirLastMoveLabel" destination="61y-Ok-IF2" id="WdN-1Z-iu9"/>
                         <outlet property="winsAndRoundsLabel" destination="qbH-vN-kdo" id="fuk-yS-GMM"/>
                     </connections>
@@ -184,4 +191,9 @@
             <point key="canvasLocation" x="296.80000000000001" y="-0.44977511244377816"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/BattleBump/GameLogicManager.swift
+++ b/BattleBump/GameLogicManager.swift
@@ -10,61 +10,44 @@ import UIKit
 
 class GameLogicManager {
     
-    // TODO: Update to arc4random the length of the Moveset movesArray and return appropriately
-    func pickRandomMove() -> String {
-        return ["Rock", "Paper", "Scissors"].randomElement() ?? ""
+    var movesetInUse: Moveset!
+    
+    init(moveset: Moveset) {
+        movesetInUse = moveset
     }
     
-    // TODO: Update this to use Moveset dict of dict comparisons
+    func pickRandomMove() -> Move {
+        return movesetInUse.moveArray.randomElement()!
+    }
+    
     func generateResults(game: Game) -> Game {        
+        guard let myMove = game.me.selectedMove, let opponentMove = game.opponent.selectedMove else {
+            fatalError("Tried to generateResults but there was an error with moves")
+        }
         let roundsPlayed = game.rounds.count
+        let myMoveName = myMove.moveName
+        let opponentMoveName = opponentMove.moveName
         
-        if let myMove = game.me.selectedMove, let opponentMove = game.opponent.selectedMove {
-            if myMove == opponentMove {
-                game.rounds["round\(roundsPlayed+1)"] = ["winner": "TIE", "sentence":"\(myMove) ties \(opponentMove)"]
-            }
-            else {
-                if myMove == "Rock" && opponentMove == "Paper" {
-                    opponentWins(round: roundsPlayed, game: game)
+        if myMoveName == opponentMoveName {
+            game.rounds["round\(roundsPlayed+1)"] = ["winner": "TIE", "sentence":"\(myMoveName) ties \(opponentMoveName)"]
+        } else {
+            if myMove.moveVerbs[opponentMoveName] != nil {
+                game.myRoundWins += 1
+                if let winningVerb = myMove.moveVerbs[opponentMoveName] {
+                    let winningSentence = myMoveName + " " + winningVerb + " " + opponentMoveName
+                    print("Winning sentence is \(winningSentence)")
+                    game.rounds["round\(roundsPlayed+1)"] = ["winner": "\(game.me.name)", "sentence":winningSentence]
                 }
-                if myMove == "Rock" && opponentMove == "Scissors" {
-                    iWin(round: roundsPlayed, game: game)
-                }
-                if myMove == "Scissors" && opponentMove == "Paper" {
-                    iWin(round: roundsPlayed, game: game)
-                }
-                if myMove == "Scissors" && opponentMove == "Rock" {
-                    opponentWins(round: roundsPlayed, game: game)
-                }
-                if myMove == "Paper" && opponentMove == "Scissors" {
-                    opponentWins(round: roundsPlayed, game: game)
-                }
-                if myMove == "Paper" && opponentMove == "Rock" {
-                    iWin(round: roundsPlayed, game: game)
+            } else {
+                game.opponentRoundWins += 1
+                if let winningVerb = opponentMove.moveVerbs[myMoveName] {
+                    let winningSentence = opponentMoveName + " " + winningVerb + " " + myMoveName
+                    print("Winning sentence is \(winningSentence)")
+                    game.rounds["round\(roundsPlayed+1)"] = ["winner": "\(game.opponent.name)", "sentence":winningSentence]
                 }
             }
-            
         }
         
         return game
     }
-    
-    func iWin(round:Int, game: Game) {
-        guard let move1 = game.me.selectedMove, let move2 = game.opponent.selectedMove else {
-            print("Couldn't add to game rounds because selectedMoves are invalid")
-            return
-        }
-        game.myRoundWins += 1
-        game.rounds["round\(round+1)"] = ["winner": "\(game.me.name)", "sentence":"\(move1) beats \(move2)"]
-    }
-    
-    func opponentWins(round: Int, game: Game) {
-        guard let move1 = game.opponent.selectedMove, let move2 = game.me.selectedMove else {
-            print("Couldn't add to game rounds because selectedMoves are invalid")
-            return
-        }
-        game.opponentRoundWins += 1
-        game.rounds["round\(round+1)"] = ["winner": "\(game.opponent.name)", "sentence":"\(move1) beats \(move2)"]
-    }
-    
 }

--- a/BattleBump/GameMoveCell.swift
+++ b/BattleBump/GameMoveCell.swift
@@ -1,0 +1,25 @@
+//
+//  GameMoveCell.swift
+//  BattleBump
+//
+//  Created by Callum Davies on 2020-11-14.
+//  Copyright © 2020 Callum Davies & Dave Augerinos. All rights reserved.
+//
+
+import UIKit
+
+class GameMoveCell: UICollectionViewCell {
+    
+    @IBOutlet weak var moveNameLabel: UILabel!
+    @IBOutlet weak var moveEmojiLabel: UILabel!
+    
+    var move: Move? {
+        didSet {
+            moveNameLabel.text = move?.moveName
+            moveNameLabel.textAlignment = .center
+            moveEmojiLabel.text = move?.moveEmoji
+            moveEmojiLabel.textAlignment = .center
+        }
+    }
+    
+}

--- a/BattleBump/GameViewController.swift
+++ b/BattleBump/GameViewController.swift
@@ -92,29 +92,26 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             currentGame.me.selectedMove = gameLogicManager.pickRandomMove()
         }
         
-        DispatchQueue.main.async {
-            self.rockLabel.isUserInteractionEnabled = false
-            self.paperLabel.isUserInteractionEnabled = false
-            self.scissorsLabel.isUserInteractionEnabled = false
-            
-            self.progressRing.alpha = 0.0
-            self.progressRing.setProgress(value: 5.0, animationDuration: 0.1, completion: nil)
-            
-            self.giantMoveLabel.alpha = 1.0
-            
-            switch (self.currentGame.me.selectedMove) {
-            case "Rock":
-                self.giantMoveLabel.text = "👊🏽"
-                break;
-            case "Paper":
-                self.giantMoveLabel.text = "✋🏽"
-                break;
-            case "Scissors":
-                self.giantMoveLabel.text = "✌🏽"
-                break;
-            default:
-                break;
-            }
+        self.rockLabel.isUserInteractionEnabled = false
+        self.paperLabel.isUserInteractionEnabled = false
+        self.scissorsLabel.isUserInteractionEnabled = false
+        
+        self.progressRing.alpha = 0.0
+        self.progressRing.setProgress(value: 5.0, animationDuration: 0.1, completion: nil)
+        self.giantMoveLabel.alpha = 1.0
+        
+        switch (self.currentGame.me.selectedMove) {
+        case "Rock":
+            self.giantMoveLabel.text = "👊🏽"
+            break;
+        case "Paper":
+            self.giantMoveLabel.text = "✋🏽"
+            break;
+        case "Scissors":
+            self.giantMoveLabel.text = "✌🏽"
+            break;
+        default:
+            break;
         }
         
         self.mpcManager.send(self.currentGame.me)
@@ -131,21 +128,19 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             currentGame.opponent.isReadyForNewRound = false
             currentGame.currentState = .roundEnd
             
-            DispatchQueue.main.async {
-                self.readyButton.isUserInteractionEnabled = true
-                self.readyButton.setTitle("Ready?", for: .normal)
-                self.readyButton.alpha = 1.0
-                self.readyButton.setTitleColor(.blue, for: .normal)
-                
-                if let oppoMove = self.currentGame.opponent.selectedMove {
-                    self.theirLastMoveLabel.text = "\(self.currentGame.opponent.name) last played: \(oppoMove)"
-                }
-                
-                if let lastRound = self.currentGame.rounds.keys.sorted().last {
-                    self.resultLabel.text = self.currentGame.rounds[lastRound]!["sentence"]
-                }
-                self.winsAndRoundsLabel.text = "\(self.currentGame.myRoundWins) wins / \(self.currentGame.rounds.count) rounds"
+            self.readyButton.isUserInteractionEnabled = true
+            self.readyButton.setTitle("Ready?", for: .normal)
+            self.readyButton.alpha = 1.0
+            self.readyButton.setTitleColor(.blue, for: .normal)
+            
+            if let oppoMove = self.currentGame.opponent.selectedMove {
+                self.theirLastMoveLabel.text = "\(self.currentGame.opponent.name) last played: \(oppoMove)"
             }
+            
+            if let lastRound = self.currentGame.rounds.keys.sorted().last {
+                self.resultLabel.text = self.currentGame.rounds[lastRound]!["sentence"]
+            }
+            self.winsAndRoundsLabel.text = "\(self.currentGame.myRoundWins) wins / \(self.currentGame.rounds.count) rounds"
         }
         
     }
@@ -153,21 +148,19 @@ class GameViewController: UIViewController, MPCManagerProtocol {
     func gameOver() {
         let titleString = currentGame.myRoundWins == 3 ? "You Won!" : "\(currentGame.opponent.name) Won!"
         
-        DispatchQueue.main.async {
-            //TODO: "Play again? - OK or No" - Tear down game vars / await new game
-            let alertController = UIAlertController(title: titleString, message: nil, preferredStyle: .alert)
-            let alertAction = UIAlertAction(title: "OK", style: .default, handler: {_ in
-                self.mpcManager.mySession = nil
-                
-                // Pass mpcManager back to HomeVC with a completion func? (or delegate if wanted to do heavy-handed)
-                self.onGameFinished?(self.mpcManager)
-                
-                self.currentGame = nil
-                self.dismiss(animated: true, completion: nil)
-            })
-            alertController.addAction(alertAction)
-            self.present(alertController, animated: true)
-        }
+        //TODO: "Play again? - OK or No" - Tear down game vars / await new game
+        let alertController = UIAlertController(title: titleString, message: nil, preferredStyle: .alert)
+        let alertAction = UIAlertAction(title: "OK", style: .default, handler: {_ in
+            self.mpcManager.mySession = nil
+            
+            // Pass mpcManager back to HomeVC with a completion func? (or delegate if wanted to do heavy-handed)
+            self.onGameFinished?(self.mpcManager)
+            
+            self.currentGame = nil
+            self.dismiss(animated: true, completion: nil)
+        })
+        alertController.addAction(alertAction)
+        self.present(alertController, animated: true)
     }
     
     @IBAction func readyButtonPressed(_ sender: UIButton) {
@@ -256,13 +249,13 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             if currentGame.me.isReadyForNewRound && currentGame.opponent.isReadyForNewRound {
                 roundBegin()
             }
-            /*
-            else if (currentGame.me.isReadyForNewRound == false && currentGame.opponent.isReadyForNewRound == true) {
-                print("Opponent is ready but I am not. Waiting...")
-            } else if (currentGame.me.isReadyForNewRound == true && currentGame.opponent.isReadyForNewRound == false) {
-                print("I am ready but opponent is not. Waiting...")
-            }
-            */
+        /*
+         else if (currentGame.me.isReadyForNewRound == false && currentGame.opponent.isReadyForNewRound == true) {
+         print("Opponent is ready but I am not. Waiting...")
+         } else if (currentGame.me.isReadyForNewRound == true && currentGame.opponent.isReadyForNewRound == false) {
+         print("I am ready but opponent is not. Waiting...")
+         }
+         */
         case .roundInProgress:
             if currentGame.opponent.selectedMove != nil {
                 roundEnded()
@@ -271,25 +264,23 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             print("Game ended but received player data..")
         case .none:
             print("Unexpected reception of player/game state")
-//        default:
-//            print("Unexpected reception of player/game state")
+        //        default:
+        //            print("Unexpected reception of player/game state")
         }
     }
     
     func session(session: MCSession, wasInterruptedByState state: MCSessionState) {
         
         // tear down game vars / await new game / currentGame = nil etc.
-        DispatchQueue.main.async {
-            let alertController = UIAlertController(title: "Connection interrupted! ☹️", message: nil, preferredStyle: .alert)
-            let alertAction = UIAlertAction(title: "OK", style: .default, handler: {(alert: UIAlertAction!) in
-                self.onGameFinished?(self.mpcManager)
-                self.dismiss(animated: true, completion: nil)
-            })
-            
-            alertController.addAction(alertAction)
-            self.present(alertController, animated: true)
-            // popVC?
-        }
+        let alertController = UIAlertController(title: "Connection interrupted! ☹️", message: nil, preferredStyle: .alert)
+        let alertAction = UIAlertAction(title: "OK", style: .default, handler: {(alert: UIAlertAction!) in
+            self.onGameFinished?(self.mpcManager)
+            self.dismiss(animated: true, completion: nil)
+        })
+        
+        alertController.addAction(alertAction)
+        self.present(alertController, animated: true)
+        // popVC?
     }
     
 }

--- a/BattleBump/GameViewController.swift
+++ b/BattleBump/GameViewController.swift
@@ -9,28 +9,25 @@
 import UIKit
 import MultipeerConnectivity
 
-class GameViewController: UIViewController, MPCManagerProtocol {
+class GameViewController: UIViewController,
+                          MPCManagerProtocol,
+                          UICollectionViewDataSource,
+                          UICollectionViewDelegate {
+    
     var mpcManager = MPCManager()
     var playersForNewGame = [Player]()
     
     @IBOutlet weak var progressRing: UICircularProgressRingView!
-    @IBOutlet weak var rockLabel: UILabel!
     @IBOutlet weak var theirLastMoveLabel: UILabel!
     @IBOutlet weak var resultLabel: UILabel!
-    @IBOutlet weak var paperLabel: UILabel!
-    @IBOutlet weak var scissorsLabel: UILabel!
     @IBOutlet weak var currentPlayGameLabel: UILabel!
     @IBOutlet weak var giantMoveLabel: UILabel!
     @IBOutlet weak var winsAndRoundsLabel: UILabel!
     @IBOutlet weak var readyButton: UIButton!
+    @IBOutlet weak var gameMovesCollectionView: UICollectionView!
     
     var onGameFinished: ((MPCManager) -> Void)?
-    
-    var rockConfirmationIcon: UIImageView?
-    var paperConfirmationIcon: UIImageView?
-    var scissorsConfirmationIcon: UIImageView?
-    
-    let gameLogicManager = GameLogicManager()
+    var gameLogicManager: GameLogicManager!
     var currentGame: Game!
     
     override func viewDidLoad() {
@@ -38,80 +35,60 @@ class GameViewController: UIViewController, MPCManagerProtocol {
         
         mpcManager.managerDelegate = self
         currentGame = Game(players: playersForNewGame, state: .gameStart)
+        gameLogicManager = GameLogicManager(moveset: currentGame.me.chosenMoveset!)
         configureViews()
     }
     
     func configureViews() {
+        readyButton.layer.borderWidth = 1
+        readyButton.layer.borderColor = UIColor.systemGray.cgColor
+        readyButton.layer.cornerRadius = 5
         
         currentPlayGameLabel.text = "You are playing \(currentGame.opponent.name)"
         winsAndRoundsLabel.text = "- / -"
-        
-        let confirmRock = UITapGestureRecognizer(target: self, action: #selector(didConfirmRock(_:)))
-        rockLabel.addGestureRecognizer(confirmRock)
-        
-        let confirmPaper = UITapGestureRecognizer(target: self, action: #selector(didConfirmPaper(_:)))
-        paperLabel.addGestureRecognizer(confirmPaper)
-        
-        let confirmScissors = UITapGestureRecognizer(target: self, action: #selector(didConfirmScissors(_:)))
-        scissorsLabel.addGestureRecognizer(confirmScissors)
     }
     
     func roundBegin() {
         currentGame.currentState = .roundInProgress
-        
+        currentGame.me.selectedMove = nil
+       
         DispatchQueue.main.async {
             self.readyButton.isUserInteractionEnabled = false
             self.readyButton.setTitle("", for: .normal)
             self.readyButton.alpha = 0.0
-            
-            self.rockLabel.isUserInteractionEnabled = true
-            self.paperLabel.isUserInteractionEnabled = true
-            self.scissorsLabel.isUserInteractionEnabled = true
+
+            self.gameMovesCollectionView.isUserInteractionEnabled = true
             
             self.theirLastMoveLabel.text = ""
             self.resultLabel.text = ""
             
-            self.rockConfirmationIcon?.alpha = 0.0;
-            self.paperConfirmationIcon?.alpha = 0.0;
-            self.scissorsConfirmationIcon?.alpha = 0.0;
-            
             self.progressRing.alpha = 1.0;
             self.giantMoveLabel.alpha = 0.0;
             
-            self.currentGame.me.selectedMove = nil
-        }
+            if let index = self.gameMovesCollectionView.indexPathsForSelectedItems?.first {
+                self.gameMovesCollectionView.deselectItem(at: index, animated: false)
+                self.gameMovesCollectionView.cellForItem(at: index)?.layer.borderWidth = 1
+                self.gameMovesCollectionView.cellForItem(at: index)?.layer.borderColor = UIColor.systemGray.cgColor
+            }
         
-        progressRing.setProgress(value: 0.0, animationDuration: 5.0) {
-            self.countdownEnded()
+            self.progressRing.setProgress(value: 0.0, animationDuration: 5.0) {
+                self.countdownEnded()
+            }
         }
     }
     
     func countdownEnded() {
-        
         if (currentGame.me.selectedMove == nil) {
             currentGame.me.selectedMove = gameLogicManager.pickRandomMove()
         }
         
-        self.rockLabel.isUserInteractionEnabled = false
-        self.paperLabel.isUserInteractionEnabled = false
-        self.scissorsLabel.isUserInteractionEnabled = false
-        
-        self.progressRing.alpha = 0.0
-        self.progressRing.setProgress(value: 5.0, animationDuration: 0.1, completion: nil)
-        self.giantMoveLabel.alpha = 1.0
-        
-        switch (self.currentGame.me.selectedMove) {
-        case "Rock":
-            self.giantMoveLabel.text = "👊🏽"
-            break;
-        case "Paper":
-            self.giantMoveLabel.text = "✋🏽"
-            break;
-        case "Scissors":
-            self.giantMoveLabel.text = "✌🏽"
-            break;
-        default:
-            break;
+        DispatchQueue.main.async {
+            self.gameMovesCollectionView.isUserInteractionEnabled = false
+            
+            self.progressRing.alpha = 0.0
+            self.progressRing.setProgress(value: 5.0, animationDuration: 0.1, completion: nil)
+            self.giantMoveLabel.alpha = 1.0
+            self.giantMoveLabel.text = self.currentGame.me.selectedMove?.moveEmoji
         }
         
         self.mpcManager.send(self.currentGame.me)
@@ -119,6 +96,8 @@ class GameViewController: UIViewController, MPCManagerProtocol {
     
     func roundEnded() {
         currentGame = gameLogicManager.generateResults(game: currentGame)
+        
+        print("Round Ended. My Wins are now: \(currentGame.myRoundWins). Opponent Wins are now: \(currentGame.opponentRoundWins)")
         
         if currentGame.myRoundWins == 3 || currentGame.opponentRoundWins == 3 {
             gameOver()
@@ -128,27 +107,34 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             currentGame.opponent.isReadyForNewRound = false
             currentGame.currentState = .roundEnd
             
-            self.readyButton.isUserInteractionEnabled = true
-            self.readyButton.setTitle("Ready?", for: .normal)
-            self.readyButton.alpha = 1.0
-            self.readyButton.setTitleColor(.blue, for: .normal)
+            DispatchQueue.main.async {
+                self.readyButton.isUserInteractionEnabled = true
+                self.readyButton.setTitle("Ready?", for: .normal)
+                self.readyButton.alpha = 1.0
+                self.readyButton.setTitleColor(.systemBlue, for: .normal)
             
-            if let oppoMove = self.currentGame.opponent.selectedMove {
-                self.theirLastMoveLabel.text = "\(self.currentGame.opponent.name) last played: \(oppoMove)"
+                if let oppoMove = self.currentGame.opponent.selectedMove?.moveName {
+                    self.theirLastMoveLabel.text = "\(self.currentGame.opponent.name) last played: \(oppoMove)"
+                }
+                
+                if let lastRound = self.currentGame.rounds.keys.sorted().last {
+                    self.resultLabel.text = self.currentGame.rounds[lastRound]!["sentence"]
+                    if self.currentGame.rounds[lastRound]!["winner"] == "TIE" {
+                        self.resultLabel.backgroundColor = UIColor.white
+                    } else if self.currentGame.rounds[lastRound]!["winner"] == self.currentGame.me.name {
+                        self.resultLabel.backgroundColor = UIColor.systemGreen
+                    } else {
+                        self.resultLabel.backgroundColor = UIColor.systemRed
+                    }
+                }
+                
+                self.winsAndRoundsLabel.text = "\(self.currentGame.myRoundWins) wins / \(self.currentGame.rounds.count) rounds"
             }
-            
-            if let lastRound = self.currentGame.rounds.keys.sorted().last {
-                self.resultLabel.text = self.currentGame.rounds[lastRound]!["sentence"]
-            }
-            self.winsAndRoundsLabel.text = "\(self.currentGame.myRoundWins) wins / \(self.currentGame.rounds.count) rounds"
         }
-        
     }
     
     func gameOver() {
         let titleString = currentGame.myRoundWins == 3 ? "You Won!" : "\(currentGame.opponent.name) Won!"
-        
-        //TODO: "Play again? - OK or No" - Tear down game vars / await new game
         let alertController = UIAlertController(title: titleString, message: nil, preferredStyle: .alert)
         let alertAction = UIAlertAction(title: "OK", style: .default, handler: {_ in
             self.mpcManager.mySession = nil
@@ -160,7 +146,9 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             self.dismiss(animated: true, completion: nil)
         })
         alertController.addAction(alertAction)
-        self.present(alertController, animated: true)
+        DispatchQueue.main.async {
+            self.present(alertController, animated: true)
+        }
     }
     
     @IBAction func readyButtonPressed(_ sender: UIButton) {
@@ -175,57 +163,6 @@ class GameViewController: UIViewController, MPCManagerProtocol {
         if (currentGame.me.isReadyForNewRound == true && currentGame.opponent.isReadyForNewRound == true) {
             roundBegin()
         }
-    }
-    
-    //MARK: - Confirmations -
-    
-    //TODO: Update with Collection View for larger-than-3 movesets
-    @objc func didConfirmRock(_ sender: UITapGestureRecognizer) {
-        
-        if (rockConfirmationIcon == nil) {
-            rockConfirmationIcon = UIImageView(frame: CGRect(x: rockLabel.bounds.origin.x, y: rockLabel.bounds.origin.y, width: rockLabel.bounds.size.width, height: rockLabel.bounds.size.height))
-            rockConfirmationIcon?.image = UIImage(named: "confirmationTick")?.withRenderingMode(.alwaysTemplate)
-            rockConfirmationIcon?.tintColor = UIColor.green
-            rockLabel.addSubview(rockConfirmationIcon!)
-        }
-        
-        rockConfirmationIcon?.alpha = 0.5
-        paperConfirmationIcon?.alpha = 0.0
-        scissorsConfirmationIcon?.alpha = 0.0
-        
-        currentGame.me.selectedMove = "Rock"
-    }
-    
-    @objc func didConfirmPaper(_ sender: UITapGestureRecognizer) {
-        
-        if (paperConfirmationIcon == nil) {
-            paperConfirmationIcon = UIImageView(frame: CGRect(x: paperLabel.bounds.origin.x, y: paperLabel.bounds.origin.y, width: paperLabel.bounds.size.width, height: paperLabel.bounds.size.height))
-            paperConfirmationIcon?.image = UIImage(named: "confirmationTick")?.withRenderingMode(.alwaysTemplate)
-            paperConfirmationIcon?.tintColor = UIColor.green
-            paperLabel.addSubview(paperConfirmationIcon!)
-        }
-        
-        rockConfirmationIcon?.alpha = 0.0
-        paperConfirmationIcon?.alpha = 0.5
-        scissorsConfirmationIcon?.alpha = 0.0
-        
-        currentGame.me.selectedMove = "Paper"
-    }
-    
-    @objc func didConfirmScissors(_ sender: UITapGestureRecognizer) {
-        
-        if (scissorsConfirmationIcon == nil) {
-            scissorsConfirmationIcon = UIImageView(frame: CGRect(x: scissorsLabel.bounds.origin.x, y: scissorsLabel.bounds.origin.y, width: scissorsLabel.bounds.size.width, height: scissorsLabel.bounds.size.height))
-            scissorsConfirmationIcon?.image = UIImage(named: "confirmationTick")?.withRenderingMode(.alwaysTemplate)
-            scissorsConfirmationIcon?.tintColor = UIColor.green
-            scissorsLabel.addSubview(scissorsConfirmationIcon!)
-        }
-        
-        rockConfirmationIcon?.alpha = 0.0
-        paperConfirmationIcon?.alpha = 0.0
-        scissorsConfirmationIcon?.alpha = 0.5
-        
-        currentGame.me.selectedMove = "Scissors"
     }
     
     //MARK: - MPCManagerProtocol -
@@ -249,13 +186,6 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             if currentGame.me.isReadyForNewRound && currentGame.opponent.isReadyForNewRound {
                 roundBegin()
             }
-        /*
-         else if (currentGame.me.isReadyForNewRound == false && currentGame.opponent.isReadyForNewRound == true) {
-         print("Opponent is ready but I am not. Waiting...")
-         } else if (currentGame.me.isReadyForNewRound == true && currentGame.opponent.isReadyForNewRound == false) {
-         print("I am ready but opponent is not. Waiting...")
-         }
-         */
         case .roundInProgress:
             if currentGame.opponent.selectedMove != nil {
                 roundEnded()
@@ -264,8 +194,6 @@ class GameViewController: UIViewController, MPCManagerProtocol {
             print("Game ended but received player data..")
         case .none:
             print("Unexpected reception of player/game state")
-        //        default:
-        //            print("Unexpected reception of player/game state")
         }
     }
     
@@ -281,6 +209,41 @@ class GameViewController: UIViewController, MPCManagerProtocol {
         alertController.addAction(alertAction)
         self.present(alertController, animated: true)
         // popVC?
+    }
+    
+    // MARK: - UICollectionView -
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        if let count = currentGame.me.chosenMoveset?.moveArray.count {
+            return count
+        } else {
+            print("Unknown number of moves found for numberOfItemsInSection")
+            return 1
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "gameMove", for: indexPath) as! GameMoveCell
+        cell.move = currentGame.me.chosenMoveset?.moveArray[indexPath.item]
+        cell.layer.borderWidth = 1
+        cell.layer.borderColor = UIColor.systemGray.cgColor
+        cell.layer.cornerRadius = 5
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if let selectedCell = collectionView.cellForItem(at: indexPath) {
+            selectedCell.layer.borderWidth = 5
+            selectedCell.layer.borderColor = UIColor.systemGreen.cgColor
+        }
+        currentGame.me.selectedMove = currentGame.me.chosenMoveset?.moveArray[indexPath.item]
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        if let deselectedCell = collectionView.cellForItem(at: indexPath) {
+            deselectedCell.layer.borderWidth = 1
+            deselectedCell.layer.borderColor = UIColor.systemGray.cgColor
+        }
     }
     
 }

--- a/BattleBump/Home.storyboard
+++ b/BattleBump/Home.storyboard
@@ -3,6 +3,8 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -76,9 +78,15 @@
                                     <outlet property="delegate" destination="hH9-Rs-3U1" id="9di-b7-bdz"/>
                                 </connections>
                             </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="tableViewLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lag-sV-oXq">
+                                <rect key="frame" x="16" y="480.5" width="115.5" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cnJ-fs-mxj">
-                                <rect key="frame" x="16" y="186" width="343" height="50"/>
-                                <color key="backgroundColor" red="0.98574906587600708" green="0.77739447355270386" blue="0.1804942786693573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="308.5" width="343" height="50"/>
+                                <color key="backgroundColor" systemColor="systemGreenColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="xKA-4w-byS"/>
                                 </constraints>
@@ -95,15 +103,9 @@
                                     <action selector="hostButtonPressed:" destination="hH9-Rs-3U1" eventType="touchUpInside" id="Q6C-hN-UbM"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="tableViewLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lag-sV-oXq">
-                                <rect key="frame" x="16" y="480.5" width="115.5" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bI2-LF-Cho">
-                                <rect key="frame" x="16" y="244" width="343" height="50"/>
-                                <color key="backgroundColor" red="0.91672833098305595" green="0.15419325232505798" blue="0.70312732458114624" alpha="0.60100064212328763" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="366.5" width="343" height="50"/>
+                                <color key="backgroundColor" systemColor="systemYellowColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="68g-cF-u0C"/>
                                 </constraints>
@@ -121,78 +123,78 @@
                                     <action selector="hostButtonPressed:" destination="hH9-Rs-3U1" eventType="touchUpInside" id="JXt-fI-Xl1"/>
                                 </connections>
                             </button>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="uHf-vm-35b">
-                                <rect key="frame" x="16" y="116" width="343" height="46"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXN-Oi-Zhp">
-                                        <rect key="frame" x="0.0" y="0.0" width="46" height="46"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="ZXN-Oi-Zhp" secondAttribute="height" multiplier="1:1" id="Eg7-E6-j5P"/>
-                                        </constraints>
-                                        <state key="normal" title="Button"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Select a Moveset:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qkB-Qg-cqk">
+                                <rect key="frame" x="16" y="87" width="136" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="N6P-Jw-WQF">
+                                <rect key="frame" x="16" y="116" width="343" height="129"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="1BV-RY-ual">
+                                    <size key="itemSize" width="110" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="moveset" id="nCd-VO-dg0" customClass="MovesetCell" customModule="BattleBump" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="1" width="110" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="e0N-uR-d4U">
+                                            <rect key="frame" x="0.0" y="0.0" width="110" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vgB-wf-OR9">
+                                                    <rect key="frame" x="0.0" y="0.0" width="110" height="100"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fOp-DJ-LBq">
+                                                    <rect key="frame" x="8" y="107" width="100" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="110" height="128"/>
                                         <connections>
-                                            <action selector="movesetOneButtonPressed:" destination="hH9-Rs-3U1" eventType="touchUpInside" id="YFw-bb-LxH"/>
+                                            <outlet property="movesetCellImageView" destination="vgB-wf-OR9" id="PkN-1b-EO4"/>
+                                            <outlet property="movesetCellLabel" destination="fOp-DJ-LBq" id="YsX-CQ-dTr"/>
                                         </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MPH-is-gUl">
-                                        <rect key="frame" x="148.5" y="0.0" width="46" height="46"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="MPH-is-gUl" secondAttribute="height" multiplier="1:1" id="SM5-Ct-4d9"/>
-                                        </constraints>
-                                        <state key="normal" title="Button"/>
-                                        <connections>
-                                            <action selector="movesetTwoButtonPressed:" destination="hH9-Rs-3U1" eventType="touchUpInside" id="nVo-PM-AyI"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZbW-Zc-CTu">
-                                        <rect key="frame" x="297" y="0.0" width="46" height="46"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="ZbW-Zc-CTu" secondAttribute="height" multiplier="1:1" id="Viy-MA-Kp6"/>
-                                        </constraints>
-                                        <state key="normal" title="Button"/>
-                                        <connections>
-                                            <action selector="movesetThreeButtonPressed:" destination="hH9-Rs-3U1" eventType="touchUpInside" id="LMg-7v-mYq"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="ZXN-Oi-Zhp" firstAttribute="height" secondItem="MPH-is-gUl" secondAttribute="height" id="1Rq-1g-t5y"/>
-                                    <constraint firstItem="MPH-is-gUl" firstAttribute="centerX" secondItem="uHf-vm-35b" secondAttribute="centerX" id="9mM-62-1i0"/>
-                                    <constraint firstItem="ZbW-Zc-CTu" firstAttribute="width" secondItem="MPH-is-gUl" secondAttribute="width" id="OD9-mP-xZk"/>
-                                    <constraint firstItem="ZbW-Zc-CTu" firstAttribute="height" secondItem="MPH-is-gUl" secondAttribute="height" id="cWv-qd-52M"/>
-                                    <constraint firstItem="ZXN-Oi-Zhp" firstAttribute="width" secondItem="MPH-is-gUl" secondAttribute="width" id="sBQ-WD-8Nk"/>
-                                </constraints>
-                            </stackView>
+                                    </collectionViewCell>
+                                </cells>
+                                <connections>
+                                    <outlet property="dataSource" destination="hH9-Rs-3U1" id="M5B-oT-XdZ"/>
+                                    <outlet property="delegate" destination="hH9-Rs-3U1" id="Gmn-Hq-WBt"/>
+                                </connections>
+                            </collectionView>
                         </subviews>
-                        <color key="backgroundColor" red="0.24358332799999999" green="0.59822409860000003" blue="0.85431868649999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="xE9-x3-0dj" firstAttribute="top" secondItem="Lag-sV-oXq" secondAttribute="bottom" constant="8" id="1fN-L5-RRb"/>
                             <constraint firstItem="bI2-LF-Cho" firstAttribute="top" secondItem="cnJ-fs-mxj" secondAttribute="bottom" constant="8" id="4sq-oP-LKK"/>
                             <constraint firstItem="bI2-LF-Cho" firstAttribute="trailing" secondItem="qfP-ZW-UOj" secondAttribute="trailingMargin" id="9Hb-Ij-uQG"/>
                             <constraint firstItem="Lag-sV-oXq" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="9tS-n0-3XX"/>
+                            <constraint firstItem="cnJ-fs-mxj" firstAttribute="centerY" secondItem="qfP-ZW-UOj" secondAttribute="centerY" id="Juk-vr-T9i"/>
                             <constraint firstAttribute="trailingMargin" secondItem="xE9-x3-0dj" secondAttribute="trailing" id="M1U-Zi-cSk"/>
                             <constraint firstAttribute="trailingMargin" secondItem="cnJ-fs-mxj" secondAttribute="trailing" id="O74-n9-Z50"/>
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="RhF-qJ-g1o"/>
                             <constraint firstItem="xE9-x3-0dj" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="Sbd-d3-LlW"/>
-                            <constraint firstItem="uHf-vm-35b" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="Vrs-CG-bdr"/>
-                            <constraint firstItem="uHf-vm-35b" firstAttribute="top" secondItem="rO4-Mp-8i8" secondAttribute="bottom" constant="66" id="Zty-PB-gJH"/>
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="cBI-5n-5Yn"/>
                             <constraint firstItem="xE9-x3-0dj" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="cug-66-C47"/>
-                            <constraint firstItem="cnJ-fs-mxj" firstAttribute="top" secondItem="uHf-vm-35b" secondAttribute="bottom" constant="24" id="e5Q-38-uBj"/>
                             <constraint firstItem="bI2-LF-Cho" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="h46-dB-7Bu"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="uHf-vm-35b" secondAttribute="trailing" id="hnt-5T-5h3"/>
                             <constraint firstItem="tLs-HQ-MIm" firstAttribute="top" secondItem="xE9-x3-0dj" secondAttribute="bottom" constant="8" id="sFr-pZ-9QO"/>
                             <constraint firstItem="rO4-Mp-8i8" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="w2z-RC-ehz"/>
                             <constraint firstItem="rO4-Mp-8i8" firstAttribute="top" secondItem="eD0-gP-xEj" secondAttribute="bottom" constant="16" id="xMo-x6-bkJ"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="movesetOneButton" destination="ZXN-Oi-Zhp" id="a2z-XC-z4W"/>
-                        <outlet property="movesetThreeButton" destination="ZbW-Zc-CTu" id="k60-as-uPB"/>
-                        <outlet property="movesetTwoButton" destination="MPH-is-gUl" id="FdT-Uf-wvs"/>
+                        <outlet property="movesetCollectionView" destination="N6P-Jw-WQF" id="ubA-Ib-Nau"/>
                         <outlet property="playerNameLabel" destination="5ct-a0-MpV" id="7gi-n6-uMw"/>
                         <outlet property="playerNameTextField" destination="8vz-MZ-4nO" id="JrJ-cV-lOP"/>
                         <outlet property="tableView" destination="xE9-x3-0dj" id="gH6-LF-SQQ"/>
@@ -222,4 +224,15 @@
             <point key="canvasLocation" x="578" y="-60"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGreenColor">
+            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/BattleBump/Home.storyboard
+++ b/BattleBump/Home.storyboard
@@ -85,34 +85,44 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="N6P-Jw-WQF">
-                                <rect key="frame" x="16" y="118.5" width="343" height="150"/>
+                                <rect key="frame" x="16" y="102.5" width="343" height="166"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="1BV-RY-ual">
-                                    <size key="itemSize" width="100" height="100"/>
+                                    <size key="itemSize" width="100" height="138"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="moveset" id="nCd-VO-dg0" customClass="MovesetCell" customModule="BattleBump" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="25" width="100" height="100"/>
+                                        <rect key="frame" x="0.0" y="8" width="100" height="150"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="e0N-uR-d4U">
-                                            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="100" height="150"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vgB-wf-OR9">
                                                     <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="vgB-wf-OR9" secondAttribute="height" multiplier="50:50" id="z7O-PW-dxZ"/>
+                                                    </constraints>
                                                 </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EtF-ux-6rT">
+                                                    <rect key="frame" x="14.5" y="108" width="71" height="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="vgB-wf-OR9" firstAttribute="top" secondItem="e0N-uR-d4U" secondAttribute="top" id="3ar-hK-hPW"/>
+                                                <constraint firstItem="EtF-ux-6rT" firstAttribute="top" secondItem="vgB-wf-OR9" secondAttribute="bottom" constant="8" id="DDj-La-bWz"/>
                                                 <constraint firstItem="vgB-wf-OR9" firstAttribute="centerX" secondItem="e0N-uR-d4U" secondAttribute="centerX" id="OHW-lA-moU"/>
+                                                <constraint firstItem="EtF-ux-6rT" firstAttribute="centerX" secondItem="e0N-uR-d4U" secondAttribute="centerX" id="Pow-KH-eOX"/>
                                                 <constraint firstItem="vgB-wf-OR9" firstAttribute="width" secondItem="e0N-uR-d4U" secondAttribute="width" id="YXd-L1-1c3"/>
-                                                <constraint firstItem="vgB-wf-OR9" firstAttribute="height" secondItem="e0N-uR-d4U" secondAttribute="height" id="aN7-y0-Z8J"/>
-                                                <constraint firstItem="vgB-wf-OR9" firstAttribute="centerY" secondItem="e0N-uR-d4U" secondAttribute="centerY" id="pQb-tB-lXg"/>
                                             </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="100" height="100"/>
+                                        <size key="customSize" width="100" height="150"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                                 <integer key="value" value="10"/>
@@ -121,6 +131,7 @@
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <outlet property="movesetCellImageView" destination="vgB-wf-OR9" id="PkN-1b-EO4"/>
+                                            <outlet property="movesetCellLabel" destination="EtF-ux-6rT" id="pxR-LA-XRY"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -169,7 +180,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select a Moveset:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qkB-Qg-cqk">
-                                <rect key="frame" x="120" y="82" width="135.5" height="20.5"/>
+                                <rect key="frame" x="120" y="66" width="135.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -187,7 +198,7 @@
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="centerY" secondItem="qfP-ZW-UOj" secondAttribute="centerY" id="Juk-vr-T9i"/>
                             <constraint firstAttribute="trailingMargin" secondItem="xE9-x3-0dj" secondAttribute="trailing" id="M1U-Zi-cSk"/>
                             <constraint firstAttribute="trailingMargin" secondItem="cnJ-fs-mxj" secondAttribute="trailing" id="O74-n9-Z50"/>
-                            <constraint firstItem="qkB-Qg-cqk" firstAttribute="top" secondItem="rO4-Mp-8i8" secondAttribute="bottom" constant="32" id="PLn-jf-zK3"/>
+                            <constraint firstItem="qkB-Qg-cqk" firstAttribute="top" secondItem="rO4-Mp-8i8" secondAttribute="bottom" constant="16" id="PLn-jf-zK3"/>
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="RhF-qJ-g1o"/>
                             <constraint firstItem="xE9-x3-0dj" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="Sbd-d3-LlW"/>
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="cBI-5n-5Yn"/>

--- a/BattleBump/Home.storyboard
+++ b/BattleBump/Home.storyboard
@@ -57,18 +57,27 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="playerNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E6M-bN-uWk">
-                                                    <rect key="frame" x="199.5" y="22" width="127.5" height="20.5"/>
+                                                    <rect key="frame" x="8" y="22" width="127.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="movesetNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Phb-DU-BNt">
+                                                    <rect key="frame" x="184" y="22" width="151" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailingMargin" secondItem="E6M-bN-uWk" secondAttribute="trailing" id="BPC-gr-TkB"/>
+                                                <constraint firstItem="E6M-bN-uWk" firstAttribute="leading" secondItem="BHc-fN-oga" secondAttribute="leading" constant="8" id="63N-L9-2MB"/>
                                                 <constraint firstItem="E6M-bN-uWk" firstAttribute="centerY" secondItem="BHc-fN-oga" secondAttribute="centerY" id="BqD-cJ-veg"/>
+                                                <constraint firstItem="Phb-DU-BNt" firstAttribute="centerY" secondItem="BHc-fN-oga" secondAttribute="centerY" id="E8f-U1-v7d"/>
+                                                <constraint firstAttribute="trailing" secondItem="Phb-DU-BNt" secondAttribute="trailing" constant="8" id="sVa-1O-DBf"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
+                                            <outlet property="movesetNameLabel" destination="Phb-DU-BNt" id="XQs-VA-R0N"/>
                                             <outlet property="playerNameLabel" destination="E6M-bN-uWk" id="ofR-Kf-zyf"/>
                                         </connections>
                                     </tableViewCell>

--- a/BattleBump/Home.storyboard
+++ b/BattleBump/Home.storyboard
@@ -84,6 +84,55 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="N6P-Jw-WQF">
+                                <rect key="frame" x="16" y="116" width="343" height="129"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="1BV-RY-ual">
+                                    <size key="itemSize" width="110" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="moveset" id="nCd-VO-dg0" customClass="MovesetCell" customModule="BattleBump" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="1" width="110" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="e0N-uR-d4U">
+                                            <rect key="frame" x="0.0" y="0.0" width="110" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vgB-wf-OR9">
+                                                    <rect key="frame" x="0.0" y="0.0" width="110" height="100"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fOp-DJ-LBq">
+                                                    <rect key="frame" x="8" y="107" width="100" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="110" height="128"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="10"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <outlet property="movesetCellImageView" destination="vgB-wf-OR9" id="PkN-1b-EO4"/>
+                                            <outlet property="movesetCellLabel" destination="fOp-DJ-LBq" id="YsX-CQ-dTr"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <connections>
+                                    <outlet property="dataSource" destination="hH9-Rs-3U1" id="M5B-oT-XdZ"/>
+                                    <outlet property="delegate" destination="hH9-Rs-3U1" id="Gmn-Hq-WBt"/>
+                                </connections>
+                            </collectionView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cnJ-fs-mxj">
                                 <rect key="frame" x="16" y="308.5" width="343" height="50"/>
                                 <color key="backgroundColor" systemColor="systemGreenColor"/>
@@ -124,55 +173,12 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Select a Moveset:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qkB-Qg-cqk">
-                                <rect key="frame" x="16" y="87" width="136" height="21"/>
+                                <rect key="frame" x="119" y="87" width="136" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="N6P-Jw-WQF">
-                                <rect key="frame" x="16" y="116" width="343" height="129"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="1BV-RY-ual">
-                                    <size key="itemSize" width="110" height="128"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="moveset" id="nCd-VO-dg0" customClass="MovesetCell" customModule="BattleBump" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1" width="110" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="e0N-uR-d4U">
-                                            <rect key="frame" x="0.0" y="0.0" width="110" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vgB-wf-OR9">
-                                                    <rect key="frame" x="0.0" y="0.0" width="110" height="100"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fOp-DJ-LBq">
-                                                    <rect key="frame" x="8" y="107" width="100" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </collectionViewCellContentView>
-                                        <size key="customSize" width="110" height="128"/>
-                                        <connections>
-                                            <outlet property="movesetCellImageView" destination="vgB-wf-OR9" id="PkN-1b-EO4"/>
-                                            <outlet property="movesetCellLabel" destination="fOp-DJ-LBq" id="YsX-CQ-dTr"/>
-                                        </connections>
-                                    </collectionViewCell>
-                                </cells>
-                                <connections>
-                                    <outlet property="dataSource" destination="hH9-Rs-3U1" id="M5B-oT-XdZ"/>
-                                    <outlet property="delegate" destination="hH9-Rs-3U1" id="Gmn-Hq-WBt"/>
-                                </connections>
-                            </collectionView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>

--- a/BattleBump/Home.storyboard
+++ b/BattleBump/Home.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hH9-Rs-3U1">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -84,38 +84,35 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="N6P-Jw-WQF">
-                                <rect key="frame" x="16" y="116" width="343" height="129"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="N6P-Jw-WQF">
+                                <rect key="frame" x="16" y="118.5" width="343" height="150"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="1BV-RY-ual">
-                                    <size key="itemSize" width="110" height="128"/>
+                                    <size key="itemSize" width="100" height="100"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="moveset" id="nCd-VO-dg0" customClass="MovesetCell" customModule="BattleBump" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1" width="110" height="128"/>
+                                        <rect key="frame" x="0.0" y="25" width="100" height="100"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="e0N-uR-d4U">
-                                            <rect key="frame" x="0.0" y="0.0" width="110" height="128"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vgB-wf-OR9">
-                                                    <rect key="frame" x="0.0" y="0.0" width="110" height="100"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vgB-wf-OR9">
+                                                    <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fOp-DJ-LBq">
-                                                    <rect key="frame" x="8" y="107" width="100" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="vgB-wf-OR9" firstAttribute="centerX" secondItem="e0N-uR-d4U" secondAttribute="centerX" id="OHW-lA-moU"/>
+                                                <constraint firstItem="vgB-wf-OR9" firstAttribute="width" secondItem="e0N-uR-d4U" secondAttribute="width" id="YXd-L1-1c3"/>
+                                                <constraint firstItem="vgB-wf-OR9" firstAttribute="height" secondItem="e0N-uR-d4U" secondAttribute="height" id="aN7-y0-Z8J"/>
+                                                <constraint firstItem="vgB-wf-OR9" firstAttribute="centerY" secondItem="e0N-uR-d4U" secondAttribute="centerY" id="pQb-tB-lXg"/>
+                                            </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="110" height="128"/>
+                                        <size key="customSize" width="100" height="100"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                                 <integer key="value" value="10"/>
@@ -124,7 +121,6 @@
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <outlet property="movesetCellImageView" destination="vgB-wf-OR9" id="PkN-1b-EO4"/>
-                                            <outlet property="movesetCellLabel" destination="fOp-DJ-LBq" id="YsX-CQ-dTr"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -172,9 +168,8 @@
                                     <action selector="hostButtonPressed:" destination="hH9-Rs-3U1" eventType="touchUpInside" id="JXt-fI-Xl1"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Select a Moveset:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qkB-Qg-cqk">
-                                <rect key="frame" x="119" y="87" width="136" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select a Moveset:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qkB-Qg-cqk">
+                                <rect key="frame" x="120" y="82" width="135.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -184,22 +179,31 @@
                         <constraints>
                             <constraint firstItem="xE9-x3-0dj" firstAttribute="top" secondItem="Lag-sV-oXq" secondAttribute="bottom" constant="8" id="1fN-L5-RRb"/>
                             <constraint firstItem="bI2-LF-Cho" firstAttribute="top" secondItem="cnJ-fs-mxj" secondAttribute="bottom" constant="8" id="4sq-oP-LKK"/>
+                            <constraint firstItem="N6P-Jw-WQF" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="5uE-6R-7fR"/>
                             <constraint firstItem="bI2-LF-Cho" firstAttribute="trailing" secondItem="qfP-ZW-UOj" secondAttribute="trailingMargin" id="9Hb-Ij-uQG"/>
                             <constraint firstItem="Lag-sV-oXq" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="9tS-n0-3XX"/>
+                            <constraint firstItem="qkB-Qg-cqk" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="F1l-B4-6rZ"/>
+                            <constraint firstItem="cnJ-fs-mxj" firstAttribute="top" secondItem="N6P-Jw-WQF" secondAttribute="bottom" constant="40" id="Fzt-9i-Kib"/>
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="centerY" secondItem="qfP-ZW-UOj" secondAttribute="centerY" id="Juk-vr-T9i"/>
                             <constraint firstAttribute="trailingMargin" secondItem="xE9-x3-0dj" secondAttribute="trailing" id="M1U-Zi-cSk"/>
                             <constraint firstAttribute="trailingMargin" secondItem="cnJ-fs-mxj" secondAttribute="trailing" id="O74-n9-Z50"/>
+                            <constraint firstItem="qkB-Qg-cqk" firstAttribute="top" secondItem="rO4-Mp-8i8" secondAttribute="bottom" constant="32" id="PLn-jf-zK3"/>
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="RhF-qJ-g1o"/>
                             <constraint firstItem="xE9-x3-0dj" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="Sbd-d3-LlW"/>
                             <constraint firstItem="cnJ-fs-mxj" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="cBI-5n-5Yn"/>
                             <constraint firstItem="xE9-x3-0dj" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="cug-66-C47"/>
+                            <constraint firstAttribute="trailing" secondItem="N6P-Jw-WQF" secondAttribute="trailing" constant="16" id="fY9-hW-Ftc"/>
                             <constraint firstItem="bI2-LF-Cho" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leadingMargin" id="h46-dB-7Bu"/>
+                            <constraint firstItem="N6P-Jw-WQF" firstAttribute="leading" secondItem="qfP-ZW-UOj" secondAttribute="leading" constant="16" id="lTF-a3-eWS"/>
+                            <constraint firstItem="N6P-Jw-WQF" firstAttribute="top" secondItem="qkB-Qg-cqk" secondAttribute="bottom" constant="16" id="naw-WZ-2Vc"/>
                             <constraint firstItem="tLs-HQ-MIm" firstAttribute="top" secondItem="xE9-x3-0dj" secondAttribute="bottom" constant="8" id="sFr-pZ-9QO"/>
                             <constraint firstItem="rO4-Mp-8i8" firstAttribute="centerX" secondItem="qfP-ZW-UOj" secondAttribute="centerX" id="w2z-RC-ehz"/>
                             <constraint firstItem="rO4-Mp-8i8" firstAttribute="top" secondItem="eD0-gP-xEj" secondAttribute="bottom" constant="16" id="xMo-x6-bkJ"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="editButton" destination="bI2-LF-Cho" id="EqO-IM-adl"/>
+                        <outlet property="hostButton" destination="cnJ-fs-mxj" id="omn-uL-sQp"/>
                         <outlet property="movesetCollectionView" destination="N6P-Jw-WQF" id="ubA-Ib-Nau"/>
                         <outlet property="playerNameLabel" destination="5ct-a0-MpV" id="7gi-n6-uMw"/>
                         <outlet property="playerNameTextField" destination="8vz-MZ-4nO" id="JrJ-cV-lOP"/>

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -26,13 +26,7 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
     var foundPeersArray = [MCPeerID]()
     var connectedPlayersArray = [Player]()
     lazy var refreshControl = UIRefreshControl()
-    //    var movesetButtonArray = [UIButton]()
-    //    var movesetOne: Moveset?
-    //    var movesetTwo: Moveset?
-    //    var movesetThree: Moveset?
     var selectedMoveset: Moveset?
-    //    var movesetArray = [Moveset]()
-    //    var selectedMovesetIndex: Int?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -45,13 +39,6 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
         movesetCollectionView.reloadData()
         setupMPCManager()
     }
-    
-    /*
-     override func viewWillAppear(_ animated: Bool) {
-     super.viewWillAppear(animated)
-     tableView.reloadData()
-     }
-     */
     
     //MARK: - IBActions -
     
@@ -107,8 +94,8 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
             let standardRPSMoveset = Moveset(name: "Standard RPS", movesAndVerbs: standardMoves, emojisDict: standardEmojis)
             
             playerMovesets.append(contentsOf: repeatElement(standardRPSMoveset, count: 3))
-            print("Player Movesets: \(playerMovesets)")
         }
+        print("Movesets loaded: \(playerMovesets.map({ $0.movesetName }))")
         
     }
     

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -32,6 +32,7 @@ class HomeViewController: UIViewController,
     var playerName: String?
     var playerMovesets = [Moveset]()
     var movesetImages = [UIImage]()
+//    var movesetImageNames = ["movesetImage1","movesetImage2","movesetImage3"]
     var me: Player!
     var foundPeersArray = [MCPeerID]()
     var connectedPlayersArray = [Player]()
@@ -119,22 +120,25 @@ class HomeViewController: UIViewController,
                 playerMovesets = movesets
             }
             print("Movesets loaded from defaults")
-            let imageData = UserDefaults.standard.object(forKey: "image") as! Data
-            print(imageData)
-//            movesetImages = imageData.map({ UIImage(data: $0)})
             
+            movesetImages = ["movesetImage1","movesetImage2","movesetImage3"].map({ getSavedImage(named:$0)! })
         } else {
-//        if defaults.dictionaryRepresentation().keys.contains("playerMovesets") {
-//            playerMovesets = defaults.object(forKey: "playerMovesets") as! [Moveset]
-//            movesetImages = defaults.object(forKey: "movesetImages") as! [UIImage]
-//        } else {
             let rock = Move(moveName: "Rock", moveEmoji: "👊", moveVerbs: ["vsScissors": "crushes"])
             let paper = Move(moveName: "Paper", moveEmoji: "✋", moveVerbs: ["vsRock": "wraps around"])
             let scissors = Move(moveName: "Scissors", moveEmoji: "✌️", moveVerbs: ["vsPaper": "cuts"])
             let standardRPSMoveset = Moveset(moves: [rock, paper, scissors])
-            
             playerMovesets.append(contentsOf: repeatElement(standardRPSMoveset, count: 3))
-            movesetImages.append(contentsOf: repeatElement(UIImage(named: "2-simplex")!, count: 3))
+            
+            if let img1 = UIImage(named: "Circled 1"),
+               let img2 = UIImage(named: "Circled 2"),
+               let img3 = UIImage(named: "Circled 3") {
+                movesetImages.append(img1)
+                saveImage(image: img1, filename: "movesetImage1")
+                movesetImages.append(img2)
+                saveImage(image: img2, filename: "movesetImage2")
+                movesetImages.append(img3)
+                saveImage(image: img3, filename: "movesetImage3")
+            }
             print("Movesets NOT loaded from defaults")
         }
         
@@ -217,10 +221,8 @@ class HomeViewController: UIViewController,
         if let encodedMovesets = try? encoder.encode(playerMovesets) {
             let defaults = UserDefaults.standard
             defaults.set(encodedMovesets, forKey: "playerMovesets")
-            //        defaults.set(movesetImages, forKey: "movesetImages")
         }
-        let imagePNGs = movesetImages.map({ $0.pngData() })
-        UserDefaults.standard.set(imagePNGs, forKey: "movesetImages")
+        saveImage(image: screenshot, filename: "movesetImage\(Int(selectedIndex.item+1))")
         
         movesetCollectionView.deselectItem(at: selectedIndex, animated: false)
         disableInteractionWith(button: editButton)
@@ -314,4 +316,27 @@ class HomeViewController: UIViewController,
         }
     }
     
+    func saveImage(image: UIImage, filename: String) {
+        guard let data = image.pngData() else {
+            return
+        }
+        guard let directory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false) as URL else {
+            return
+        }
+        do {
+            try data.write(to: directory.appendingPathComponent(filename))
+            print("Saved Image to \(directory.appendingPathComponent(filename))")
+            return
+        } catch {
+            print(error.localizedDescription)
+            return
+        }
+    }
+    
+    func getSavedImage(named: String) -> UIImage? {
+        if let dir = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false) {
+            return UIImage(contentsOfFile: URL(fileURLWithPath: dir.absoluteString).appendingPathComponent(named).path)
+        }
+        return nil
+    }
 }

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -87,11 +87,12 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
             playerMovesets = defaults.object(forKey: "playerMovesets") as! [Moveset]
         } else {
             //TODO: Give the player more than the 3 basic 'RPS' movesets? e.g. Weapon triangle/Pokemon/Spock&Lizard RPS/umop versions?
-            let standardMoves = ["Rock": ["vs-Scissors": "crushes"],
+            let standardMoves = ["Rock", "Paper", "Scissors"]
+            let standardMoveVerbs = ["Rock": ["vs-Scissors": "crushes"],
                                  "Paper": ["vs-Rock": "wraps around"],
                                  "Scissors": ["vs-Paper": "cuts"]]
             let standardEmojis = ["Rock": "👊", "Paper": "✋", "Scissors": "✌️"]
-            let standardRPSMoveset = Moveset(name: "Standard RPS", movesAndVerbs: standardMoves, emojisDict: standardEmojis)
+            let standardRPSMoveset = Moveset(name: "Standard RPS", moveNamesArray: standardMoves, movesAndVerbs: standardMoveVerbs, emojisDict: standardEmojis)
             
             playerMovesets.append(contentsOf: repeatElement(standardRPSMoveset, count: 3))
         }

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -188,9 +188,7 @@ class HomeViewController: UIViewController,
             me.chosenMoveset = player.chosenMoveset
         }
         mpcManager.stopAdvertisingToPeers()
-        guard me.chosenMoveset != nil,
-              player.chosenMoveset != nil,
-              me.chosenMoveset?.movesetName == player.chosenMoveset?.movesetName else {
+        guard me.chosenMoveset != nil else {
             fatalError("chosenMoveset is not in sync between me and player")
         }
         startNewGame(with: player)
@@ -209,7 +207,16 @@ class HomeViewController: UIViewController,
     
     func startNewGame(with player: Player) {
         playersForNewGame = [me, player]
-        self.performSegue(withIdentifier: "startGame", sender: self)
+        DispatchQueue.main.async {
+            self.performSegue(withIdentifier: "startGame", sender: self)
+        }
+    }
+    
+    func gameEnded() {
+        foundPeersArray = []
+        foundPeersMovesetNames.removeAll()
+        tableView.reloadData()
+        mpcManager.findPeers()
     }
     
     // MARK: - MovesetEditingProtocol -
@@ -246,6 +253,7 @@ class HomeViewController: UIViewController,
                 }
                 self.mpcManager = mpcManager
                 self.mpcManager.managerDelegate = self
+                self.gameEnded()
             }
             gameVC.playersForNewGame = playersForNewGame
         } else if segue.identifier == "edit" {

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -87,16 +87,14 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
             playerMovesets = defaults.object(forKey: "playerMovesets") as! [Moveset]
         } else {
             //TODO: Give the player more than the 3 basic 'RPS' movesets? e.g. Weapon triangle/Pokemon/Spock&Lizard RPS/umop versions?
-            let standardMoves = ["Rock", "Paper", "Scissors"]
-            let standardMoveVerbs = ["Rock": ["vs-Scissors": "crushes"],
-                                 "Paper": ["vs-Rock": "wraps around"],
-                                 "Scissors": ["vs-Paper": "cuts"]]
-            let standardEmojis = ["Rock": "👊", "Paper": "✋", "Scissors": "✌️"]
-            let standardRPSMoveset = Moveset(name: "Standard RPS", moveNamesArray: standardMoves, movesAndVerbs: standardMoveVerbs, emojisDict: standardEmojis)
+            let rock = Move(moveName: "Rock", moveEmoji: "👊", moveVerbs: ["vsScissors": "crushes"])
+            let paper = Move(moveName: "Paper", moveEmoji: "✋", moveVerbs: ["vsRock": "wraps around"])
+            let scissors = Move(moveName: "Scissors", moveEmoji: "✌️", moveVerbs: ["vsPaper": "cuts"])
+            let standardRPSMoveset = Moveset(moves: [rock, paper, scissors])
             
             playerMovesets.append(contentsOf: repeatElement(standardRPSMoveset, count: 3))
         }
-        print("Movesets loaded: \(playerMovesets.map({ $0.movesetName }))")
+        print("Movesets loaded: \(playerMovesets.map({ $0.moveArray }))")
         
     }
     

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -65,8 +65,7 @@ class HomeViewController: UIViewController,
     @IBAction func editButtonPressed(_ sender: UIButton) {
         //take current moveset selection and pass to MovesetViewController
         guard movesetCollectionView.indexPathsForSelectedItems != nil, selectedMoveset != nil else {
-            print("Edit button was pressed without a selectedMoveset")
-            return
+            fatalError("Edit button was pressed without a selectedMoveset")
         }
         self.performSegue(withIdentifier: "edit", sender: self)
     }
@@ -125,7 +124,7 @@ class HomeViewController: UIViewController,
             let rock = Move(moveName: "Rock", moveEmoji: "👊", moveVerbs: ["Scissors": "crushes"])
             let paper = Move(moveName: "Paper", moveEmoji: "✋", moveVerbs: ["Rock": "wraps around"])
             let scissors = Move(moveName: "Scissors", moveEmoji: "✌️", moveVerbs: ["Paper": "cuts"])
-            let standardRPSMoveset = Moveset(moves: [rock, paper, scissors])
+            let standardRPSMoveset = Moveset(moves: [rock, paper, scissors], name: "Standard RPS")
             playerMovesets.append(contentsOf: repeatElement(standardRPSMoveset, count: 3))
             
             if let img1 = UIImage(named: "Circled 1"),
@@ -284,6 +283,7 @@ class HomeViewController: UIViewController,
         cell.moveset = playerMovesets[indexPath.item]
         cell.movesetCellImageView.image = movesetImages[indexPath.item]
         cell.movesetCellImageView.contentMode = UIView.ContentMode.scaleAspectFit
+        cell.movesetCellLabel.text = playerMovesets[indexPath.item].movesetName
         cell.layer.borderWidth = 1
         cell.layer.borderColor = UIColor.systemGray.cgColor
         return cell

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -122,9 +122,9 @@ class HomeViewController: UIViewController,
             
             movesetImages = ["movesetImage1","movesetImage2","movesetImage3"].map({ getSavedImage(named:$0)! })
         } else {
-            let rock = Move(moveName: "Rock", moveEmoji: "👊", moveVerbs: ["vsScissors": "crushes"])
-            let paper = Move(moveName: "Paper", moveEmoji: "✋", moveVerbs: ["vsRock": "wraps around"])
-            let scissors = Move(moveName: "Scissors", moveEmoji: "✌️", moveVerbs: ["vsPaper": "cuts"])
+            let rock = Move(moveName: "Rock", moveEmoji: "👊", moveVerbs: ["Scissors": "crushes"])
+            let paper = Move(moveName: "Paper", moveEmoji: "✋", moveVerbs: ["Rock": "wraps around"])
+            let scissors = Move(moveName: "Scissors", moveEmoji: "✌️", moveVerbs: ["Paper": "cuts"])
             let standardRPSMoveset = Moveset(moves: [rock, paper, scissors])
             playerMovesets.append(contentsOf: repeatElement(standardRPSMoveset, count: 3))
             

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -9,19 +9,29 @@
 import UIKit
 import MultipeerConnectivity
 
-class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDelegate, UITableViewDataSource, UITextFieldDelegate, UICollectionViewDelegate, UICollectionViewDataSource {
-    
+class HomeViewController: UIViewController,
+                          MPCManagerProtocol,
+                          MovesetEditingProtocol,
+                          UITableViewDelegate,
+                          UITableViewDataSource,
+                          UITextFieldDelegate,
+                          UICollectionViewDelegate,
+                          UICollectionViewDataSource,
+                          UICollectionViewDelegateFlowLayout {
     
     @IBOutlet weak var playerNameLabel: UILabel!
     @IBOutlet weak var playerNameTextField: UITextField!
     @IBOutlet weak var tableViewLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var movesetCollectionView: UICollectionView!
+    @IBOutlet weak var editButton: UIButton!
+    @IBOutlet weak var hostButton: UIButton!
     
     var mpcManager = MPCManager()
     var playersForNewGame = [Player]()
     var playerName: String?
     var playerMovesets = [Moveset]()
+    var movesetImages = [UIImage]()
     var me: Player!
     var foundPeersArray = [MCPeerID]()
     var connectedPlayersArray = [Player]()
@@ -40,11 +50,21 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
         setupMPCManager()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        if movesetCollectionView.indexPathsForSelectedItems != nil {
+            disableInteractionWith(button: editButton)
+            disableInteractionWith(button: hostButton)
+        } else {
+            enableInteractionWith(button: editButton)
+            enableInteractionWith(button: hostButton)
+        }
+    }
+    
     //MARK: - IBActions -
     
     @IBAction func editButtonPressed(_ sender: UIButton) {
         //take current moveset selection and pass to MovesetViewController
-        guard selectedMoveset != nil else {
+        guard movesetCollectionView.indexPathsForSelectedItems != nil, selectedMoveset != nil else {
             print("Edit button was pressed without a selectedMoveset")
             return
         }
@@ -52,24 +72,34 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
     }
     
     @IBAction func hostButtonPressed(_ sender: UIButton) {
+        guard movesetCollectionView.indexPathsForSelectedItems != nil, selectedMoveset != nil else {
+            return
+        }
         mpcManager.advertiseToPeers()
     }
     
     @IBAction func playerNameTextFieldDidEndEditing(_ sender: UITextField) {
-        
         guard let text = sender.text, !text.isEmpty, playerName != sender.text else {
             return
         }
-        
         playerName = text
         me.name = text
         let defaults = UserDefaults.standard
         defaults.set(text, forKey: "playerName")
         playerNameTextField.resignFirstResponder()
-        
     }
     
     //MARK: - Functions -
+    
+    func enableInteractionWith(button: UIButton) {
+        button.isUserInteractionEnabled = true
+        button.alpha = 1.0
+    }
+    
+    func disableInteractionWith(button: UIButton) {
+        button.isUserInteractionEnabled = false
+        button.alpha = 0.5
+    }
     
     func loadUserDefaults() {
         
@@ -83,18 +113,30 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
         playerNameTextField.text = playerName
         me = Player(name: playerName!)
         
-        if defaults.dictionaryRepresentation().keys.contains("playerMovesets") {
-            playerMovesets = defaults.object(forKey: "playerMovesets") as! [Moveset]
+        if let loadedMovesets = defaults.object(forKey: "playerMovesets") as? Data {
+            let decoder = JSONDecoder()
+            if let movesets = try? decoder.decode([Moveset].self, from: loadedMovesets) {
+                playerMovesets = movesets
+            }
+            print("Movesets loaded from defaults")
+            let imageData = UserDefaults.standard.object(forKey: "image") as! Data
+            print(imageData)
+//            movesetImages = imageData.map({ UIImage(data: $0)})
+            
         } else {
-            //TODO: Give the player more than the 3 basic 'RPS' movesets? e.g. Weapon triangle/Pokemon/Spock&Lizard RPS/umop versions?
+//        if defaults.dictionaryRepresentation().keys.contains("playerMovesets") {
+//            playerMovesets = defaults.object(forKey: "playerMovesets") as! [Moveset]
+//            movesetImages = defaults.object(forKey: "movesetImages") as! [UIImage]
+//        } else {
             let rock = Move(moveName: "Rock", moveEmoji: "👊", moveVerbs: ["vsScissors": "crushes"])
             let paper = Move(moveName: "Paper", moveEmoji: "✋", moveVerbs: ["vsRock": "wraps around"])
             let scissors = Move(moveName: "Scissors", moveEmoji: "✌️", moveVerbs: ["vsPaper": "cuts"])
             let standardRPSMoveset = Moveset(moves: [rock, paper, scissors])
             
             playerMovesets.append(contentsOf: repeatElement(standardRPSMoveset, count: 3))
+            movesetImages.append(contentsOf: repeatElement(UIImage(named: "2-simplex")!, count: 3))
+            print("Movesets NOT loaded from defaults")
         }
-        print("Movesets loaded: \(playerMovesets.map({ $0.moveArray }))")
         
     }
     
@@ -163,6 +205,29 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
         }
     }
     
+    // MARK: - MovesetEditingProtocol -
+    func movesetEditingEndedWith(moveset: Moveset, screenshot: UIImage) {
+        guard let selectedIndex = movesetCollectionView.indexPathsForSelectedItems?.first else {
+            return
+        }
+        playerMovesets[selectedIndex.item] = moveset
+        movesetImages[selectedIndex.item] = screenshot
+        
+        let encoder = JSONEncoder()
+        if let encodedMovesets = try? encoder.encode(playerMovesets) {
+            let defaults = UserDefaults.standard
+            defaults.set(encodedMovesets, forKey: "playerMovesets")
+            //        defaults.set(movesetImages, forKey: "movesetImages")
+        }
+        let imagePNGs = movesetImages.map({ $0.pngData() })
+        UserDefaults.standard.set(imagePNGs, forKey: "movesetImages")
+        
+        movesetCollectionView.deselectItem(at: selectedIndex, animated: false)
+        disableInteractionWith(button: editButton)
+        disableInteractionWith(button: hostButton)
+        movesetCollectionView.reloadData()
+    }
+    
     // MARK: - Navigation -
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -181,6 +246,7 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
         } else if segue.identifier == "edit" {
             let destinationNavigationController = segue.destination as! UINavigationController
             let targetController = destinationNavigationController.topViewController as! MovesetViewController
+            targetController.editingDelegate = self
             targetController.movesetInProgress = selectedMoveset
         }
     }
@@ -215,9 +281,15 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "moveset", for: indexPath) as! MovesetCell
         cell.moveset = playerMovesets[indexPath.item]
+        cell.movesetCellImageView.image = movesetImages[indexPath.item]
         cell.movesetCellImageView.contentMode = UIView.ContentMode.scaleAspectFit
-        
+        cell.layer.borderWidth = 1
+        cell.layer.borderColor = UIColor.systemGray.cgColor
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: movesetCollectionView.frame.width / 3.2, height: movesetCollectionView.frame.height)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -226,15 +298,19 @@ class HomeViewController: UIViewController, MPCManagerProtocol, UITableViewDeleg
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedMoveset = playerMovesets[indexPath.item]
-        
         if let cell = collectionView.cellForItem(at: indexPath) as? MovesetCell {
-            cell.backgroundColor = UIColor.green
+            cell.layer.borderWidth = 5
+            cell.layer.borderColor = UIColor.systemGray.cgColor
         }
+        enableInteractionWith(button: editButton)
+        enableInteractionWith(button: hostButton)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         if let cell = collectionView.cellForItem(at: indexPath) as? MovesetCell {
             cell.backgroundColor = UIColor.white
+            cell.layer.borderWidth = 1
+            cell.layer.borderColor = UIColor.systemGray.cgColor
         }
     }
     

--- a/BattleBump/HomeViewController.swift
+++ b/BattleBump/HomeViewController.swift
@@ -32,7 +32,6 @@ class HomeViewController: UIViewController,
     var playerName: String?
     var playerMovesets = [Moveset]()
     var movesetImages = [UIImage]()
-//    var movesetImageNames = ["movesetImage1","movesetImage2","movesetImage3"]
     var me: Player!
     var foundPeersArray = [MCPeerID]()
     var connectedPlayersArray = [Player]()

--- a/BattleBump/HostCell.swift
+++ b/BattleBump/HostCell.swift
@@ -11,6 +11,7 @@ import UIKit
 class HostCell: UITableViewCell {
 
     @IBOutlet weak var playerNameLabel: UILabel!
+    @IBOutlet weak var movesetNameLabel: UILabel!
     
     var host: Player! {
         didSet {

--- a/BattleBump/MPCManager.swift
+++ b/BattleBump/MPCManager.swift
@@ -28,6 +28,7 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
     var mySession : MCSession?
     
     var foundPeersArray = [MCPeerID]()
+    var foundPeersMovesetNames = [MCPeerID: String]()
     var connectedPlayersDictionary = [MCPeerID:Player]()
     
     // MARK: - MCSessionDelegate -
@@ -43,6 +44,7 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
             
         } else if (state == .notConnected) {
             foundPeersArray = []
+            foundPeersMovesetNames.removeAll()
             managerDelegate?.session(session: session, wasInterruptedByState: state)
         }
     }
@@ -106,9 +108,11 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
     
     func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         print("Found peer: \(peerID)")
-
         if (!foundPeersArray.contains(peerID)) {
             foundPeersArray.append(peerID)
+        }
+        if foundPeersMovesetNames[peerID] == nil {
+            foundPeersMovesetNames[peerID] = info?["movesetName"]
         }
         
         //eventually have moveset in discoveryInfo, decode
@@ -122,6 +126,7 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
         
         if let indexOfLostHost = foundPeersArray.firstIndex(of: peerID) {
             foundPeersArray.remove(at: indexOfLostHost)
+            foundPeersMovesetNames.removeValue(forKey: peerID)
         } else {
             print("Peer wasn't removed")
         }
@@ -131,15 +136,18 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
     
     //MARK: -  MPCManager Client Methods -
     
-    func advertiseToPeers() {
-        
+    func advertiseToPeers(movesetName: String) {
         // TODO: add chosen moveset name to discoveryInfo
-        let dict = ["testKey":"testValue"]
+        let dict = ["movesetName":movesetName]
         myAdvertiser = MCNearbyServiceAdvertiser(peer: myPeerID, discoveryInfo:dict, serviceType: "RPSgame")
-        print("Advertising with \(myPeerID.displayName)")
-        
+        print("Advertising with \(myPeerID.displayName), discoveryInfo: \(dict)")
         myAdvertiser?.delegate = self
         myAdvertiser?.startAdvertisingPeer()
+    }
+    
+    func stopAdvertisingToPeers() {
+        print("Stopping advertising")
+        myAdvertiser?.stopAdvertisingPeer()
     }
     
     

--- a/BattleBump/MPCManager.swift
+++ b/BattleBump/MPCManager.swift
@@ -65,11 +65,6 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
         // MCSession Delegate callback when receiving data from a peer in a given session
         print("Received data from \(peerID.displayName)")
         
-//        guard let player = NSKeyedUnarchiver.unarchiveObject(with: data) as? Player else {
-//            print("Could not decode invitee properly")
-//            return
-//        }
-        
         do {
             let player = try JSONDecoder().decode(Player.self, from: data)
             managerDelegate?.receivedPlayerDataFromPeer(player)
@@ -77,10 +72,6 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
             print(error.localizedDescription)
             print("Could not decode player properly")
         }
-        
-        //still have to unarchive data or .JSONdecode
-        
-        //receivedPlayerDataFromPeer() as above?
     }
     
     
@@ -115,11 +106,7 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
     
     func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         print("Found peer: \(peerID)")
-        
-        //        let newHostPlayerFound = Host(hostPeerID: peerID, emoji: (info?["emoji"])!)
-        
-        //        let playerName = peerID.displayName.components(separatedBy: ":")[0]
-        //        let newHostPlayerFound = Player(name: playerName, peerID: peerID)
+
         if (!foundPeersArray.contains(peerID)) {
             foundPeersArray.append(peerID)
         }
@@ -139,12 +126,6 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
             print("Peer wasn't removed")
         }
         
-        //removes lost Host
-//        if let lostHost = foundPlayersDictionary.first(where: { $0.peerID == peerID }) {
-//            if let index = foundPlayersDictionary.firstIndex(of: lostHost) {
-//                foundPlayersDictionary.remove(at: index)
-//            }
-//        }
         managerDelegate?.didChangeFoundPeers()
     }
     
@@ -185,12 +166,6 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
     func send(_ player: Player) {
         
         print("Sending Player Update...")
-        //        let dictionary = ["invitee": invitee]
-        //        let data = NSKeyedArchiver.archivedData(withRootObject: dictionary)
-        
-        /// JSON encode instead of archive?
-//        let data = NSKeyedArchiver.archivedData(withRootObject: player)
-
         
         do {
             let data = try JSONEncoder().encode(player)
@@ -199,13 +174,6 @@ class MPCManager: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
             print(error.localizedDescription)
             print("Could not send player update properly")
         }
-        
-//        do {
-//            try mySession?.send(data, toPeers: (mySession?.connectedPeers)!, with: .reliable)
-//        } catch {
-//            print(error.localizedDescription)
-//            print("Could not send player update properly")
-//        }
         
     }
     

--- a/BattleBump/Move.swift
+++ b/BattleBump/Move.swift
@@ -1,0 +1,21 @@
+//
+//  Move.swift
+//  BattleBump
+//
+//  Created by Callum Davies on 2020-10-20.
+//  Copyright © 2020 Callum Davies & Dave Augerinos. All rights reserved.
+//
+
+import Foundation
+
+struct Move: Codable {
+    var moveName: String            // "Rock"
+    var moveEmoji: String           // "👊"
+    var moveVerbs: [String: String] // ["vsScissors": "crushes", "vsLizard": "crushes"]
+    
+//    init(name: String, emoji: String, verbs: [String: String] ) {
+//        moveName = name
+//        moveEmoji = emoji
+//        moveVerbs = verbs
+//    }
+}

--- a/BattleBump/Move.swift
+++ b/BattleBump/Move.swift
@@ -11,11 +11,5 @@ import Foundation
 struct Move: Codable {
     var moveName: String            // "Rock"
     var moveEmoji: String           // "👊"
-    var moveVerbs: [String: String] // ["vsScissors": "crushes", "vsLizard": "crushes"]
-    
-//    init(name: String, emoji: String, verbs: [String: String] ) {
-//        moveName = name
-//        moveEmoji = emoji
-//        moveVerbs = verbs
-//    }
+    var moveVerbs: [String: String] // ["Scissors": "crushes", "Lizard": "crushes"]
 }

--- a/BattleBump/Moveset.swift
+++ b/BattleBump/Moveset.swift
@@ -10,16 +10,15 @@ import Foundation
 
 class Moveset: Codable {
     
-    var movesetName: String                                 // "Standard RPS"
-    var numberOfMoves: Int                                  //  3
-    var moveNamesArray: [String]                                //  ["Rock", "Paper", "Scissors"]
-    var winningVerbDictionary: [String: [String: String]]?   // ["Rock": ["vsScissors": "crushes"], "Paper": ["vsRock": "wraps around"], "Scissors": ["vsPaper": "cuts"]]
-    //TODO: include moveImages/moveEmojis
+    var movesetName: String                                     // "Standard RPS"
+    var movesAndVerbsDictionary: [String: [String: String]]?    // ["Rock": ["vsScissors": "crushes"],"Paper": ["vsRock": "wraps around"],"Scissors": ["vsPaper": "cuts"]]
     
-    init(name: String, numberOfMoves: Int, movesArray: [String]) {
+    var moveEmojis : [String: String]?    // ["Rock": <Image/Emoji>,"Paper": <Image/Emoji>,"Scissors": <Image/Emoji>] -- TODO: Allow images? e.g. picture of a hand in an orientation (but Image doesn't conform to Codable out of the box etc)
+    
+    init(name: String, movesAndVerbs: [String: [String: String]], emojisDict: [String: String]) {
         movesetName = name
-        self.numberOfMoves = numberOfMoves
-        self.moveNamesArray = movesArray
+        movesAndVerbsDictionary = movesAndVerbs
+        moveEmojis = emojisDict
     }
     
 }

--- a/BattleBump/Moveset.swift
+++ b/BattleBump/Moveset.swift
@@ -11,9 +11,11 @@ import Foundation
 class Moveset: Codable {
     
     var moveArray: [Move]
+    var movesetName: String?
 
-    init(moves: [Move]) {
+    init(moves: [Move], name: String) {
         moveArray = moves
+        movesetName = name
     }
     
 }

--- a/BattleBump/Moveset.swift
+++ b/BattleBump/Moveset.swift
@@ -11,12 +11,14 @@ import Foundation
 class Moveset: Codable {
     
     var movesetName: String                                     // "Standard RPS"
+    var moves: [String]
     var movesAndVerbsDictionary: [String: [String: String]]?    // ["Rock": ["vsScissors": "crushes"],"Paper": ["vsRock": "wraps around"],"Scissors": ["vsPaper": "cuts"]]
     
     var moveEmojis : [String: String]?    // ["Rock": <Image/Emoji>,"Paper": <Image/Emoji>,"Scissors": <Image/Emoji>] -- TODO: Allow images? e.g. picture of a hand in an orientation (but Image doesn't conform to Codable out of the box etc)
     
-    init(name: String, movesAndVerbs: [String: [String: String]], emojisDict: [String: String]) {
+    init(name: String, moveNamesArray: [String], movesAndVerbs: [String: [String: String]], emojisDict: [String: String]) {
         movesetName = name
+        moves = moveNamesArray
         movesAndVerbsDictionary = movesAndVerbs
         moveEmojis = emojisDict
     }

--- a/BattleBump/Moveset.swift
+++ b/BattleBump/Moveset.swift
@@ -11,7 +11,7 @@ import Foundation
 class Moveset: Codable {
     
     var movesetName: String                                     // "Standard RPS"
-    var moves: [String]
+    var moves: [String] //TODO: replace with var moves: [Move]  // ["Rock", "Paper", "Scissors"]
     var movesAndVerbsDictionary: [String: [String: String]]?    // ["Rock": ["vsScissors": "crushes"],"Paper": ["vsRock": "wraps around"],"Scissors": ["vsPaper": "cuts"]]
     
     var moveEmojis : [String: String]?    // ["Rock": <Image/Emoji>,"Paper": <Image/Emoji>,"Scissors": <Image/Emoji>] -- TODO: Allow images? e.g. picture of a hand in an orientation (but Image doesn't conform to Codable out of the box etc)

--- a/BattleBump/Moveset.swift
+++ b/BattleBump/Moveset.swift
@@ -10,17 +10,10 @@ import Foundation
 
 class Moveset: Codable {
     
-    var movesetName: String                                     // "Standard RPS"
-    var moves: [String] //TODO: replace with var moves: [Move]  // ["Rock", "Paper", "Scissors"]
-    var movesAndVerbsDictionary: [String: [String: String]]?    // ["Rock": ["vsScissors": "crushes"],"Paper": ["vsRock": "wraps around"],"Scissors": ["vsPaper": "cuts"]]
-    
-    var moveEmojis : [String: String]?    // ["Rock": <Image/Emoji>,"Paper": <Image/Emoji>,"Scissors": <Image/Emoji>] -- TODO: Allow images? e.g. picture of a hand in an orientation (but Image doesn't conform to Codable out of the box etc)
-    
-    init(name: String, moveNamesArray: [String], movesAndVerbs: [String: [String: String]], emojisDict: [String: String]) {
-        movesetName = name
-        moves = moveNamesArray
-        movesAndVerbsDictionary = movesAndVerbs
-        moveEmojis = emojisDict
+    var moveArray: [Move]
+
+    init(moves: [Move]) {
+        moveArray = moves
     }
     
 }

--- a/BattleBump/MovesetCell.swift
+++ b/BattleBump/MovesetCell.swift
@@ -13,10 +13,6 @@ class MovesetCell: UICollectionViewCell {
     @IBOutlet weak var movesetCellImageView: UIImageView!
     @IBOutlet weak var movesetCellLabel: UILabel!
     
-    var moveset: Moveset! {
-        didSet {
-            movesetCellImageView.image = UIImage(named: "2-simplex")
-        }
-    }
+    var moveset: Moveset!
     
 }

--- a/BattleBump/MovesetCell.swift
+++ b/BattleBump/MovesetCell.swift
@@ -15,26 +15,8 @@ class MovesetCell: UICollectionViewCell {
     
     var moveset: Moveset! {
         didSet {
-            configure()
-        }
-    }
-    
-    fileprivate func configure() {
-        switch moveset.movesAndVerbsDictionary!.keys.count {
-        case 3:
-            movesetCellImageView.image = UIImage(named: "2-simplex")
-        case 5:
-            movesetCellImageView.image = UIImage(named: "4-simplex")
-        case 7:
-            movesetCellImageView.image = UIImage(named: "6-simplex")
-        case 9:
-            movesetCellImageView.image = UIImage(named: "8-simplex")
-        default:
-            print("Unknown number of moves when configuring MovesetCell")
             movesetCellImageView.image = UIImage(named: "2-simplex")
         }
-        
-        movesetCellLabel.text = moveset.movesetName
     }
     
 }

--- a/BattleBump/MovesetCell.swift
+++ b/BattleBump/MovesetCell.swift
@@ -9,27 +9,32 @@
 import UIKit
 
 class MovesetCell: UICollectionViewCell {
-  
-  @IBOutlet weak var movesetImageView: UIImageView!
-  
-  var moveset: Moveset! {
-    didSet {
-      configure()
+    
+    @IBOutlet weak var movesetCellImageView: UIImageView!
+    @IBOutlet weak var movesetCellLabel: UILabel!
+    
+    var moveset: Moveset! {
+        didSet {
+            configure()
+        }
     }
-  }
-  
-  fileprivate func configure() {
-  
-    switch moveset.numberOfMoves {
-    case 3 :
-      movesetImageView.image = UIImage(named: "TriangleImage")
-    case 5:
-      movesetImageView.image = UIImage(named: "PentagonImage")
-    case 7:
-      movesetImageView.image = UIImage(named: "SeptagonImage")
-    default:
-      movesetImageView.image = UIImage(named: "TriangleImage")
+    
+    fileprivate func configure() {
+        switch moveset.movesAndVerbsDictionary!.keys.count {
+        case 3:
+            movesetCellImageView.image = UIImage(named: "2-simplex")
+        case 5:
+            movesetCellImageView.image = UIImage(named: "4-simplex")
+        case 7:
+            movesetCellImageView.image = UIImage(named: "6-simplex")
+        case 9:
+            movesetCellImageView.image = UIImage(named: "8-simplex")
+        default:
+            print("Unknown number of moves when configuring MovesetCell")
+            movesetCellImageView.image = UIImage(named: "2-simplex")
+        }
+        
+        movesetCellLabel.text = moveset.movesetName
     }
-  }
-  
+    
 }

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dDE-ye-sp9">
-    <device id="retina4_0" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dDE-ye-sp9">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fUa-jq-8vD">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fUa-jq-8vD">
                                 <rect key="frame" x="80" y="518" width="160" height="30"/>
                                 <state key="normal" title="Pick verbs!"/>
                                 <connections>
@@ -33,22 +27,22 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="numberOfOutcomesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6z-Mg-FYW">
-                                <rect key="frame" x="61" y="400" width="198" height="20.5"/>
+                                <rect key="frame" x="61.5" y="380" width="197" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NDb-75-mRl">
-                                <rect key="frame" x="16" y="98" width="288" height="30"/>
+                                <rect key="frame" x="16" y="78" width="288" height="30"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wrn-JP-yNg">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wrn-JP-yNg">
                                         <rect key="frame" x="0.0" y="0.0" width="144" height="30"/>
                                         <state key="normal" title="-2 moves"/>
                                         <connections>
                                             <action selector="minus2MovesButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="bOt-yx-cQn"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-BN-BJJ">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-BN-BJJ">
                                         <rect key="frame" x="144" y="0.0" width="144" height="30"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
                                         <state key="normal" title="+2 moves"/>
@@ -62,7 +56,7 @@
                                 </constraints>
                             </stackView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="C9z-BJ-u7D">
-                                <rect key="frame" x="40" y="136" width="240" height="240"/>
+                                <rect key="frame" x="40" y="116" width="240" height="240"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="C9z-BJ-u7D" secondAttribute="height" multiplier="1:1" id="MY6-lp-vNf"/>
                                 </constraints>
@@ -97,8 +91,10 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="minusMovesButton" destination="wrn-JP-yNg" id="hq0-97-T4T"/>
                         <outlet property="movesetImageView" destination="C9z-BJ-u7D" id="U0s-c3-BE9"/>
                         <outlet property="numberOfOutcomesLabel" destination="e6z-Mg-FYW" id="CvW-nq-0RI"/>
+                        <outlet property="plusMovesButton" destination="ATZ-BN-BJJ" id="bIh-f5-3Ee"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xkX-M8-fE4" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -118,24 +114,23 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="77" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gpX-Qb-9jn">
-                                <rect key="frame" x="16" y="64" width="288" height="504"/>
+                                <rect key="frame" x="16" y="44" width="288" height="524"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="verbCell" rowHeight="77" id="SNg-VZ-nX7">
                                         <rect key="frame" x="0.0" y="28" width="288" height="77"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SNg-VZ-nX7" id="GRG-oA-62S">
-                                            <rect key="frame" x="0.0" y="0.0" width="288" height="76.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="288" height="77"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="beat" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tXz-qr-XDw">
-                                                    <rect key="frame" x="15" y="23" width="50" height="30"/>
-                                                    <nil key="textColor"/>
+                                                    <rect key="frame" x="16" y="21.5" width="57" height="34"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H29-zq-Hp1">
-                                                    <rect key="frame" x="73" y="28" width="42" height="21"/>
+                                                    <rect key="frame" x="81" y="28" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -181,7 +176,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="xsB-EB-fHt" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="dLF-XQ-kLR">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -199,7 +194,7 @@
                 <navigationController storyboardIdentifier="movesetNavigation" automaticallyAdjustsScrollViewInsets="NO" id="dDE-ye-sp9" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="YUM-76-QU9">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--MovesetName-->
+        <!--Moveset View Controller-->
         <scene sceneID="mnF-hA-5GJ">
             <objects>
                 <viewController storyboardIdentifier="MovesetViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Uu6-FD-VKU" customClass="MovesetViewController" customModule="BattleBump" customModuleProvider="target" sceneMemberID="viewController">
@@ -21,7 +21,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fUa-jq-8vD">
-                                <rect key="frame" x="94" y="617" width="187.5" height="30"/>
+                                <rect key="frame" x="94" y="583" width="187.5" height="30"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <state key="normal" title="Edit verbs"/>
                                 <connections>
@@ -29,37 +29,8 @@
                                     <segue destination="xsB-EB-fHt" kind="showDetail" identifier="pickVerbs" id="s7y-GH-rho"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="numberOfOutcomesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6z-Mg-FYW">
-                                <rect key="frame" x="89" y="533.5" width="197" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NDb-75-mRl">
-                                <rect key="frame" x="16" y="78" width="343" height="30"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wrn-JP-yNg">
-                                        <rect key="frame" x="0.0" y="0.0" width="171.5" height="30"/>
-                                        <state key="normal" title="-2 moves"/>
-                                        <connections>
-                                            <action selector="minus2MovesButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="bOt-yx-cQn"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-BN-BJJ">
-                                        <rect key="frame" x="171.5" y="0.0" width="171.5" height="30"/>
-                                        <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
-                                        <state key="normal" title="+2 moves"/>
-                                        <connections>
-                                            <action selector="plus2MovesButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="UvD-t9-n5e"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="wrn-JP-yNg" firstAttribute="width" secondItem="ATZ-BN-BJJ" secondAttribute="width" id="7Vg-uZ-OY4"/>
-                                </constraints>
-                            </stackView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="b58-Bd-60D">
-                                <rect key="frame" x="8" y="111" width="359" height="330.5"/>
+                                <rect key="frame" x="8" y="160.5" width="359" height="330.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="b58-Bd-60D" secondAttribute="height" multiplier="343:316" id="Y2E-d0-4LW"/>
@@ -95,63 +66,137 @@
                                     <outlet property="delegate" destination="Uu6-FD-VKU" id="RFa-33-H2m"/>
                                 </connections>
                             </collectionView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JmH-pq-FLD">
-                                <rect key="frame" x="60" y="456.5" width="127.5" height="20.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="EhS-qJ-hW6">
+                                <rect key="frame" x="53" y="499" width="269" height="34"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JmH-pq-FLD">
+                                        <rect key="frame" x="0.0" y="0.0" width="127.5" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1JM-5e-FIm">
+                                        <rect key="frame" x="134.5" y="0.0" width="134.5" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                        <connections>
+                                            <outlet property="delegate" destination="Uu6-FD-VKU" id="RK3-cv-7ub"/>
+                                        </connections>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="1JM-5e-FIm" firstAttribute="width" secondItem="EhS-qJ-hW6" secondAttribute="width" multiplier="0.5" id="Vxy-0Q-hct"/>
+                                </constraints>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="QEo-ja-byC">
+                                <rect key="frame" x="55.5" y="541" width="264" height="34"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveEmojiLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3F1-Tg-alM">
+                                        <rect key="frame" x="0.0" y="0.0" width="124" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fnY-of-lMq">
+                                        <rect key="frame" x="132" y="0.0" width="132" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                        <connections>
+                                            <outlet property="delegate" destination="Uu6-FD-VKU" id="kD3-fk-DTn"/>
+                                        </connections>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="fnY-of-lMq" firstAttribute="width" secondItem="QEo-ja-byC" secondAttribute="width" multiplier="0.5" id="7ag-hU-n6q"/>
+                                </constraints>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="pIW-L0-hDF">
+                                <rect key="frame" x="51.5" y="52" width="272" height="34"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="gameNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2PG-wT-dDm">
+                                        <rect key="frame" x="0.0" y="0.0" width="129" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yMr-Vf-GF1">
+                                        <rect key="frame" x="136" y="0.0" width="136" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                        <connections>
+                                            <outlet property="delegate" destination="sqQ-sm-cqk" id="8LQ-Qq-Wx0"/>
+                                        </connections>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="yMr-Vf-GF1" firstAttribute="width" secondItem="pIW-L0-hDF" secondAttribute="width" multiplier="0.5" id="nva-6N-IjC"/>
+                                </constraints>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="numberOfOutcomesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6z-Mg-FYW">
+                                <rect key="frame" x="89" y="132" width="197" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1JM-5e-FIm">
-                                <rect key="frame" x="195.5" y="449.5" width="171.5" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                                <connections>
-                                    <action selector="moveNameTextFieldDidEndEditing:" destination="Uu6-FD-VKU" eventType="editingDidEnd" id="PdL-9F-vDX"/>
-                                    <outlet property="delegate" destination="Uu6-FD-VKU" id="RK3-cv-7ub"/>
-                                </connections>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fnY-of-lMq">
-                                <rect key="frame" x="195.5" y="491.5" width="171.5" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                                <connections>
-                                    <action selector="moveEmojiTextFieldDidEndEditing:" destination="Uu6-FD-VKU" eventType="editingDidEnd" id="3L4-gc-oYm"/>
-                                    <outlet property="delegate" destination="Uu6-FD-VKU" id="kD3-fk-DTn"/>
-                                </connections>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveEmojiLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3F1-Tg-alM">
-                                <rect key="frame" x="63.5" y="498.5" width="124" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NDb-75-mRl">
+                                <rect key="frame" x="79.5" y="94" width="216" height="30"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wrn-JP-yNg">
+                                        <rect key="frame" x="0.0" y="0.0" width="100" height="30"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="100" id="WQ4-rF-JKd"/>
+                                        </constraints>
+                                        <state key="normal" title="-2 moves"/>
+                                        <connections>
+                                            <action selector="minus2MovesButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="bOt-yx-cQn"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nAE-CM-MLo">
+                                        <rect key="frame" x="100" y="0.0" width="16" height="30"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="EHg-o4-5ky"/>
+                                            <constraint firstAttribute="width" constant="16" id="mMh-Dp-2M2"/>
+                                        </constraints>
+                                    </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-BN-BJJ">
+                                        <rect key="frame" x="116" y="0.0" width="100" height="30"/>
+                                        <color key="backgroundColor" systemColor="systemGray3Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="100" id="FZ7-pm-0KM"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
+                                        <state key="normal" title="+2 moves"/>
+                                        <connections>
+                                            <action selector="plus2MovesButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="UvD-t9-n5e"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="NDb-75-mRl" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="1tu-wf-CZm"/>
                             <constraint firstItem="e6z-Mg-FYW" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="3Ms-Ke-dei"/>
-                            <constraint firstItem="1JM-5e-FIm" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="centerX" constant="8" id="7NX-dR-Uz9"/>
-                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="top" secondItem="fnY-of-lMq" secondAttribute="bottom" constant="8" id="9SK-Xt-yZS"/>
-                            <constraint firstItem="1JM-5e-FIm" firstAttribute="top" secondItem="b58-Bd-60D" secondAttribute="bottom" constant="8" id="C2s-lM-Ora"/>
-                            <constraint firstItem="3F1-Tg-alM" firstAttribute="trailing" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="Dub-zt-LFg"/>
-                            <constraint firstItem="NDb-75-mRl" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="leadingMargin" id="E1r-Nx-Jcb"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="NDb-75-mRl" secondAttribute="trailing" id="LzX-yp-nvZ"/>
-                            <constraint firstItem="fnY-of-lMq" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="centerX" constant="8" id="WVG-5I-4oV"/>
-                            <constraint firstItem="JmH-pq-FLD" firstAttribute="centerY" secondItem="1JM-5e-FIm" secondAttribute="centerY" id="XLc-sg-6Rc"/>
-                            <constraint firstItem="GNp-RF-rtx" firstAttribute="top" secondItem="fUa-jq-8vD" secondAttribute="bottom" constant="20" id="Z2n-bM-7fX"/>
-                            <constraint firstItem="3F1-Tg-alM" firstAttribute="centerY" secondItem="fnY-of-lMq" secondAttribute="centerY" id="eJJ-9h-wMm"/>
-                            <constraint firstItem="JmH-pq-FLD" firstAttribute="trailing" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="gtX-Kb-QkO"/>
+                            <constraint firstItem="EhS-qJ-hW6" firstAttribute="top" secondItem="b58-Bd-60D" secondAttribute="bottom" constant="8" id="8Vx-gU-k3d"/>
+                            <constraint firstItem="pIW-L0-hDF" firstAttribute="top" secondItem="aj8-UV-fNg" secondAttribute="bottom" constant="8" id="9N9-ME-cfZ"/>
+                            <constraint firstItem="EhS-qJ-hW6" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="9vV-Ay-Qe5"/>
+                            <constraint firstItem="QEo-ja-byC" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="RaO-YA-MU5"/>
+                            <constraint firstItem="NDb-75-mRl" firstAttribute="top" secondItem="pIW-L0-hDF" secondAttribute="bottom" constant="8" symbolic="YES" id="TaP-0Z-WEX"/>
+                            <constraint firstItem="fUa-jq-8vD" firstAttribute="top" secondItem="QEo-ja-byC" secondAttribute="bottom" constant="8" id="Vqh-uJ-VHX"/>
+                            <constraint firstItem="b58-Bd-60D" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="WlU-YQ-5YF"/>
+                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="top" secondItem="NDb-75-mRl" secondAttribute="bottom" constant="8" symbolic="YES" id="c7b-W1-jFk"/>
                             <constraint firstItem="fUa-jq-8vD" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="h4e-3R-cyO"/>
-                            <constraint firstItem="NDb-75-mRl" firstAttribute="top" secondItem="aj8-UV-fNg" secondAttribute="bottom" constant="34" id="hFQ-pp-icc"/>
-                            <constraint firstItem="fnY-of-lMq" firstAttribute="trailing" secondItem="b58-Bd-60D" secondAttribute="trailing" id="k52-Pi-npz"/>
+                            <constraint firstItem="b58-Bd-60D" firstAttribute="top" secondItem="e6z-Mg-FYW" secondAttribute="bottom" constant="8" id="idp-vr-x13"/>
                             <constraint firstItem="fUa-jq-8vD" firstAttribute="width" secondItem="sqQ-sm-cqk" secondAttribute="width" multiplier="0.5" id="mL3-qz-tUo"/>
-                            <constraint firstItem="1JM-5e-FIm" firstAttribute="trailing" secondItem="b58-Bd-60D" secondAttribute="trailing" id="oh5-I0-2dc"/>
-                            <constraint firstItem="fnY-of-lMq" firstAttribute="top" secondItem="1JM-5e-FIm" secondAttribute="bottom" constant="8" id="ruM-g2-5TY"/>
+                            <constraint firstItem="pIW-L0-hDF" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="ulj-fB-v4c"/>
                             <constraint firstAttribute="trailing" secondItem="b58-Bd-60D" secondAttribute="trailing" constant="8" id="uus-fb-NfL"/>
-                            <constraint firstItem="b58-Bd-60D" firstAttribute="top" secondItem="NDb-75-mRl" secondAttribute="bottom" constant="3" id="vqd-Lt-14T"/>
+                            <constraint firstItem="QEo-ja-byC" firstAttribute="top" secondItem="EhS-qJ-hW6" secondAttribute="bottom" constant="8" id="v5J-Ns-pT1"/>
                             <constraint firstItem="b58-Bd-60D" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="leading" constant="8" id="zbr-gz-Uvo"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="MovesetName" id="xDQ-7u-lDx">
+                    <navigationItem key="navigationItem" id="xDQ-7u-lDx">
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="v3m-wf-fFe">
                             <connections>
                                 <action selector="cancelButtonPressed:" destination="Uu6-FD-VKU" id="cC2-z0-d1j"/>
@@ -170,6 +215,8 @@
                         <outlet property="moveEmojiTextField" destination="fnY-of-lMq" id="lSn-2C-b8H"/>
                         <outlet property="moveNameLabel" destination="JmH-pq-FLD" id="Mi5-mT-XSd"/>
                         <outlet property="moveNameTextField" destination="1JM-5e-FIm" id="qKL-uy-gIU"/>
+                        <outlet property="movesetNameLabel" destination="2PG-wT-dDm" id="DVb-Gs-b8i"/>
+                        <outlet property="movesetNameTextField" destination="yMr-Vf-GF1" id="zhP-Hg-1xc"/>
                         <outlet property="numberOfOutcomesLabel" destination="e6z-Mg-FYW" id="CvW-nq-0RI"/>
                         <outlet property="plusMovesButton" destination="ATZ-BN-BJJ" id="bIh-f5-3Ee"/>
                     </connections>
@@ -296,6 +343,9 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray3Color">
+            <color red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -3,6 +3,8 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,14 +22,15 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fUa-jq-8vD">
                                 <rect key="frame" x="94" y="617" width="187.5" height="30"/>
-                                <state key="normal" title="Pick verbs!"/>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <state key="normal" title="Edit verbs"/>
                                 <connections>
                                     <action selector="pickVerbsButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="0jl-I7-8b2"/>
                                     <segue destination="xsB-EB-fHt" kind="showDetail" identifier="pickVerbs" id="s7y-GH-rho"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="numberOfOutcomesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6z-Mg-FYW">
-                                <rect key="frame" x="89" y="435" width="197" height="20.5"/>
+                                <rect key="frame" x="89" y="482.5" width="197" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -55,27 +58,54 @@
                                     <constraint firstItem="wrn-JP-yNg" firstAttribute="width" secondItem="ATZ-BN-BJJ" secondAttribute="width" id="7Vg-uZ-OY4"/>
                                 </constraints>
                             </stackView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="C9z-BJ-u7D">
-                                <rect key="frame" x="40" y="116" width="295" height="295"/>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="b58-Bd-60D">
+                                <rect key="frame" x="8" y="111" width="359" height="330.5"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="C9z-BJ-u7D" secondAttribute="height" multiplier="1:1" id="MY6-lp-vNf"/>
+                                    <constraint firstAttribute="width" secondItem="b58-Bd-60D" secondAttribute="height" multiplier="343:316" id="Y2E-d0-4LW"/>
                                 </constraints>
-                            </imageView>
+                                <collectionViewLayout key="collectionViewLayout" id="M8c-3I-VGF" customClass="CircularCollectionViewLayout" customModule="BattleBump" customModuleProvider="target"/>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="circle" id="qkC-HX-Dwu" customClass="CircularCollectionViewCell" customModule="BattleBump" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="pOa-hd-fvc">
+                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sao-wj-Fqn">
+                                                    <rect key="frame" x="4" y="0.0" width="42" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="circleLabel" destination="sao-wj-Fqn" id="bsG-nB-9T3"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <connections>
+                                    <outlet property="dataSource" destination="Uu6-FD-VKU" id="hAS-V5-VUY"/>
+                                    <outlet property="delegate" destination="Uu6-FD-VKU" id="RFa-33-H2m"/>
+                                </connections>
+                            </collectionView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="3FF-lD-eiY"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="C9z-BJ-u7D" secondAttribute="trailing" constant="24" id="8BX-Ck-2Tv"/>
-                            <constraint firstItem="C9z-BJ-u7D" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="Cmy-1z-4ec"/>
+                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="3Ms-Ke-dei"/>
                             <constraint firstItem="NDb-75-mRl" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="leadingMargin" id="E1r-Nx-Jcb"/>
                             <constraint firstAttribute="trailingMargin" secondItem="NDb-75-mRl" secondAttribute="trailing" id="LzX-yp-nvZ"/>
-                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="top" secondItem="C9z-BJ-u7D" secondAttribute="bottom" constant="24" id="WhL-eO-nck"/>
                             <constraint firstItem="GNp-RF-rtx" firstAttribute="top" secondItem="fUa-jq-8vD" secondAttribute="bottom" constant="20" id="Z2n-bM-7fX"/>
                             <constraint firstItem="fUa-jq-8vD" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="h4e-3R-cyO"/>
                             <constraint firstItem="NDb-75-mRl" firstAttribute="top" secondItem="aj8-UV-fNg" secondAttribute="bottom" constant="34" id="hFQ-pp-icc"/>
+                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="top" secondItem="b58-Bd-60D" secondAttribute="bottom" constant="41" id="i3L-Px-xJq"/>
                             <constraint firstItem="fUa-jq-8vD" firstAttribute="width" secondItem="sqQ-sm-cqk" secondAttribute="width" multiplier="0.5" id="mL3-qz-tUo"/>
-                            <constraint firstItem="C9z-BJ-u7D" firstAttribute="top" secondItem="NDb-75-mRl" secondAttribute="bottom" constant="8" id="qor-3k-6wK"/>
-                            <constraint firstItem="C9z-BJ-u7D" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="leadingMargin" constant="24" id="sOv-Bn-TVY"/>
+                            <constraint firstAttribute="trailing" secondItem="b58-Bd-60D" secondAttribute="trailing" constant="8" id="uus-fb-NfL"/>
+                            <constraint firstItem="b58-Bd-60D" firstAttribute="top" secondItem="NDb-75-mRl" secondAttribute="bottom" constant="3" id="vqd-Lt-14T"/>
+                            <constraint firstItem="b58-Bd-60D" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="leading" constant="8" id="zbr-gz-Uvo"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="MovesetName" id="xDQ-7u-lDx">
@@ -92,14 +122,13 @@
                     </navigationItem>
                     <connections>
                         <outlet property="minusMovesButton" destination="wrn-JP-yNg" id="hq0-97-T4T"/>
-                        <outlet property="movesetImageView" destination="C9z-BJ-u7D" id="U0s-c3-BE9"/>
                         <outlet property="numberOfOutcomesLabel" destination="e6z-Mg-FYW" id="CvW-nq-0RI"/>
                         <outlet property="plusMovesButton" destination="ATZ-BN-BJJ" id="bIh-f5-3Ee"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xkX-M8-fE4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1290" y="97.183098591549296"/>
+            <point key="canvasLocation" x="1288.8" y="96.7016491754123"/>
         </scene>
         <!--How does...-->
         <scene sceneID="8ZK-4E-zhy">
@@ -207,4 +236,12 @@
             <point key="canvasLocation" x="544" y="97"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dDE-ye-sp9">
-    <device id="retina4_0" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -15,11 +15,11 @@
                         <viewControllerLayoutGuide type="bottom" id="GNp-RF-rtx"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="sqQ-sm-cqk">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fUa-jq-8vD">
-                                <rect key="frame" x="80" y="518" width="160" height="30"/>
+                                <rect key="frame" x="94" y="617" width="187.5" height="30"/>
                                 <state key="normal" title="Pick verbs!"/>
                                 <connections>
                                     <action selector="pickVerbsButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="0jl-I7-8b2"/>
@@ -27,23 +27,23 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="numberOfOutcomesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6z-Mg-FYW">
-                                <rect key="frame" x="61.5" y="380" width="197" height="20.5"/>
+                                <rect key="frame" x="89" y="435" width="197" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NDb-75-mRl">
-                                <rect key="frame" x="16" y="78" width="288" height="30"/>
+                                <rect key="frame" x="16" y="78" width="343" height="30"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wrn-JP-yNg">
-                                        <rect key="frame" x="0.0" y="0.0" width="144" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="171.5" height="30"/>
                                         <state key="normal" title="-2 moves"/>
                                         <connections>
                                             <action selector="minus2MovesButtonPressed:" destination="Uu6-FD-VKU" eventType="touchUpInside" id="bOt-yx-cQn"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-BN-BJJ">
-                                        <rect key="frame" x="144" y="0.0" width="144" height="30"/>
+                                        <rect key="frame" x="171.5" y="0.0" width="171.5" height="30"/>
                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
                                         <state key="normal" title="+2 moves"/>
                                         <connections>
@@ -56,7 +56,7 @@
                                 </constraints>
                             </stackView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="C9z-BJ-u7D">
-                                <rect key="frame" x="40" y="116" width="240" height="240"/>
+                                <rect key="frame" x="40" y="116" width="295" height="295"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="C9z-BJ-u7D" secondAttribute="height" multiplier="1:1" id="MY6-lp-vNf"/>
                                 </constraints>
@@ -110,18 +110,18 @@
                         <viewControllerLayoutGuide type="bottom" id="mog-ZJ-gei"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="UIL-9V-cx7">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="77" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gpX-Qb-9jn">
-                                <rect key="frame" x="16" y="44" width="288" height="524"/>
+                                <rect key="frame" x="16" y="44" width="343" height="623"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="verbCell" rowHeight="77" id="SNg-VZ-nX7">
-                                        <rect key="frame" x="0.0" y="28" width="288" height="77"/>
+                                        <rect key="frame" x="0.0" y="28" width="343" height="77"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SNg-VZ-nX7" id="GRG-oA-62S">
-                                            <rect key="frame" x="0.0" y="0.0" width="288" height="77"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="77"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="beat" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tXz-qr-XDw">
@@ -176,7 +176,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="xsB-EB-fHt" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="dLF-XQ-kLR">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -194,7 +194,7 @@
                 <navigationController storyboardIdentifier="movesetNavigation" automaticallyAdjustsScrollViewInsets="NO" id="dDE-ye-sp9" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="YUM-76-QU9">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -30,7 +30,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="numberOfOutcomesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e6z-Mg-FYW">
-                                <rect key="frame" x="89" y="482.5" width="197" height="20.5"/>
+                                <rect key="frame" x="89" y="533.5" width="197" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -95,17 +95,57 @@
                                     <outlet property="delegate" destination="Uu6-FD-VKU" id="RFa-33-H2m"/>
                                 </connections>
                             </collectionView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JmH-pq-FLD">
+                                <rect key="frame" x="60" y="456.5" width="127.5" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1JM-5e-FIm">
+                                <rect key="frame" x="195.5" y="449.5" width="171.5" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <action selector="moveNameTextFieldDidEndEditing:" destination="Uu6-FD-VKU" eventType="editingDidEnd" id="PdL-9F-vDX"/>
+                                    <outlet property="delegate" destination="Uu6-FD-VKU" id="RK3-cv-7ub"/>
+                                </connections>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fnY-of-lMq">
+                                <rect key="frame" x="195.5" y="491.5" width="171.5" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <action selector="moveEmojiTextFieldDidEndEditing:" destination="Uu6-FD-VKU" eventType="editingDidEnd" id="3L4-gc-oYm"/>
+                                    <outlet property="delegate" destination="Uu6-FD-VKU" id="kD3-fk-DTn"/>
+                                </connections>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="moveEmojiLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3F1-Tg-alM">
+                                <rect key="frame" x="63.5" y="498.5" width="124" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="e6z-Mg-FYW" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="3Ms-Ke-dei"/>
+                            <constraint firstItem="1JM-5e-FIm" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="centerX" constant="8" id="7NX-dR-Uz9"/>
+                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="top" secondItem="fnY-of-lMq" secondAttribute="bottom" constant="8" id="9SK-Xt-yZS"/>
+                            <constraint firstItem="1JM-5e-FIm" firstAttribute="top" secondItem="b58-Bd-60D" secondAttribute="bottom" constant="8" id="C2s-lM-Ora"/>
+                            <constraint firstItem="3F1-Tg-alM" firstAttribute="trailing" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="Dub-zt-LFg"/>
                             <constraint firstItem="NDb-75-mRl" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="leadingMargin" id="E1r-Nx-Jcb"/>
                             <constraint firstAttribute="trailingMargin" secondItem="NDb-75-mRl" secondAttribute="trailing" id="LzX-yp-nvZ"/>
+                            <constraint firstItem="fnY-of-lMq" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="centerX" constant="8" id="WVG-5I-4oV"/>
+                            <constraint firstItem="JmH-pq-FLD" firstAttribute="centerY" secondItem="1JM-5e-FIm" secondAttribute="centerY" id="XLc-sg-6Rc"/>
                             <constraint firstItem="GNp-RF-rtx" firstAttribute="top" secondItem="fUa-jq-8vD" secondAttribute="bottom" constant="20" id="Z2n-bM-7fX"/>
+                            <constraint firstItem="3F1-Tg-alM" firstAttribute="centerY" secondItem="fnY-of-lMq" secondAttribute="centerY" id="eJJ-9h-wMm"/>
+                            <constraint firstItem="JmH-pq-FLD" firstAttribute="trailing" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="gtX-Kb-QkO"/>
                             <constraint firstItem="fUa-jq-8vD" firstAttribute="centerX" secondItem="sqQ-sm-cqk" secondAttribute="centerX" id="h4e-3R-cyO"/>
                             <constraint firstItem="NDb-75-mRl" firstAttribute="top" secondItem="aj8-UV-fNg" secondAttribute="bottom" constant="34" id="hFQ-pp-icc"/>
-                            <constraint firstItem="e6z-Mg-FYW" firstAttribute="top" secondItem="b58-Bd-60D" secondAttribute="bottom" constant="41" id="i3L-Px-xJq"/>
+                            <constraint firstItem="fnY-of-lMq" firstAttribute="trailing" secondItem="b58-Bd-60D" secondAttribute="trailing" id="k52-Pi-npz"/>
                             <constraint firstItem="fUa-jq-8vD" firstAttribute="width" secondItem="sqQ-sm-cqk" secondAttribute="width" multiplier="0.5" id="mL3-qz-tUo"/>
+                            <constraint firstItem="1JM-5e-FIm" firstAttribute="trailing" secondItem="b58-Bd-60D" secondAttribute="trailing" id="oh5-I0-2dc"/>
+                            <constraint firstItem="fnY-of-lMq" firstAttribute="top" secondItem="1JM-5e-FIm" secondAttribute="bottom" constant="8" id="ruM-g2-5TY"/>
                             <constraint firstAttribute="trailing" secondItem="b58-Bd-60D" secondAttribute="trailing" constant="8" id="uus-fb-NfL"/>
                             <constraint firstItem="b58-Bd-60D" firstAttribute="top" secondItem="NDb-75-mRl" secondAttribute="bottom" constant="3" id="vqd-Lt-14T"/>
                             <constraint firstItem="b58-Bd-60D" firstAttribute="leading" secondItem="sqQ-sm-cqk" secondAttribute="leading" constant="8" id="zbr-gz-Uvo"/>
@@ -126,6 +166,10 @@
                     <connections>
                         <outlet property="collectionView" destination="b58-Bd-60D" id="oKL-CY-s0K"/>
                         <outlet property="minusMovesButton" destination="wrn-JP-yNg" id="hq0-97-T4T"/>
+                        <outlet property="moveEmojiLabel" destination="3F1-Tg-alM" id="QKx-jC-Gwj"/>
+                        <outlet property="moveEmojiTextField" destination="fnY-of-lMq" id="lSn-2C-b8H"/>
+                        <outlet property="moveNameLabel" destination="JmH-pq-FLD" id="Mi5-mT-XSd"/>
+                        <outlet property="moveNameTextField" destination="1JM-5e-FIm" id="qKL-uy-gIU"/>
                         <outlet property="numberOfOutcomesLabel" destination="e6z-Mg-FYW" id="CvW-nq-0RI"/>
                         <outlet property="plusMovesButton" destination="ATZ-BN-BJJ" id="bIh-f5-3Ee"/>
                     </connections>

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -73,14 +73,17 @@
                                             <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sao-wj-Fqn">
-                                                    <rect key="frame" x="4" y="0.0" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sao-wj-Fqn">
+                                                    <rect key="frame" x="4.5" y="15" width="41.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="sao-wj-Fqn" firstAttribute="centerX" secondItem="pOa-hd-fvc" secondAttribute="centerX" id="0do-Q3-bUG"/>
+                                                <constraint firstItem="sao-wj-Fqn" firstAttribute="centerY" secondItem="pOa-hd-fvc" secondAttribute="centerY" id="RYl-3R-XRH"/>
+                                            </constraints>
                                         </collectionViewCellContentView>
                                         <connections>
                                             <outlet property="circleLabel" destination="sao-wj-Fqn" id="bsG-nB-9T3"/>
@@ -121,6 +124,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="collectionView" destination="b58-Bd-60D" id="oKL-CY-s0K"/>
                         <outlet property="minusMovesButton" destination="wrn-JP-yNg" id="hq0-97-T4T"/>
                         <outlet property="numberOfOutcomesLabel" destination="e6z-Mg-FYW" id="CvW-nq-0RI"/>
                         <outlet property="plusMovesButton" destination="ATZ-BN-BJJ" id="bIh-f5-3Ee"/>

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -205,9 +205,6 @@
                                                     <rect key="frame" x="16" y="9" width="137" height="34"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits"/>
-                                                    <connections>
-                                                        <action selector="verbTextFieldDidEndEditing:" destination="YgC-0v-uRA" eventType="editingDidEnd" id="jr7-u8-kl6"/>
-                                                    </connections>
                                                 </textField>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H29-zq-Hp1">
                                                     <rect key="frame" x="161" y="15.5" width="42" height="21"/>

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dDE-ye-sp9">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -178,7 +178,7 @@
             </objects>
             <point key="canvasLocation" x="1288.8" y="96.7016491754123"/>
         </scene>
-        <!--How does...-->
+        <!--Pick the winning verbs!-->
         <scene sceneID="8ZK-4E-zhy">
             <objects>
                 <viewController id="YgC-0v-uRA" customClass="EditVerbsViewController" customModule="BattleBump" customModuleProvider="target" sceneMemberID="viewController">
@@ -190,38 +190,49 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="77" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gpX-Qb-9jn">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="52" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gpX-Qb-9jn">
                                 <rect key="frame" x="16" y="44" width="343" height="623"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="verbCell" rowHeight="77" id="SNg-VZ-nX7">
-                                        <rect key="frame" x="0.0" y="28" width="343" height="77"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="verbCell" rowHeight="52" id="SNg-VZ-nX7" customClass="VerbEditCell" customModule="BattleBump" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="343" height="52"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SNg-VZ-nX7" id="GRG-oA-62S">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="77"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="52"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="beat" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tXz-qr-XDw">
-                                                    <rect key="frame" x="16" y="21.5" width="57" height="34"/>
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="beats" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tXz-qr-XDw">
+                                                    <rect key="frame" x="16" y="9" width="137" height="34"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits"/>
+                                                    <connections>
+                                                        <action selector="beatsTextFieldDidEndEditing:" destination="YgC-0v-uRA" eventType="editingDidEnd" id="qm7-8P-kzc"/>
+                                                    </connections>
                                                 </textField>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H29-zq-Hp1">
-                                                    <rect key="frame" x="81" y="28" width="42" height="21"/>
+                                                    <rect key="frame" x="161" y="15.5" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="tXz-qr-XDw" firstAttribute="width" secondItem="GRG-oA-62S" secondAttribute="width" multiplier="0.4" id="Dwh-ux-LeE"/>
                                                 <constraint firstItem="tXz-qr-XDw" firstAttribute="leading" secondItem="GRG-oA-62S" secondAttribute="leadingMargin" id="IOa-su-3r2"/>
                                                 <constraint firstItem="H29-zq-Hp1" firstAttribute="centerY" secondItem="GRG-oA-62S" secondAttribute="centerY" id="IiO-ir-cRb"/>
                                                 <constraint firstItem="H29-zq-Hp1" firstAttribute="leading" secondItem="tXz-qr-XDw" secondAttribute="trailing" constant="8" id="Unh-wB-ra2"/>
                                                 <constraint firstItem="tXz-qr-XDw" firstAttribute="centerY" secondItem="GRG-oA-62S" secondAttribute="centerY" id="x0J-Wt-Ote"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="losingMoveLabel" destination="H29-zq-Hp1" id="K3W-iZ-bhK"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="YgC-0v-uRA" id="4p9-V2-qgU"/>
+                                    <outlet property="delegate" destination="YgC-0v-uRA" id="ZTN-ss-ZmE"/>
+                                </connections>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -232,7 +243,7 @@
                             <constraint firstItem="gpX-Qb-9jn" firstAttribute="leading" secondItem="UIL-9V-cx7" secondAttribute="leadingMargin" id="rCd-4U-YYP"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="How does..." id="sKk-nD-wyF">
+                    <navigationItem key="navigationItem" title="Pick the winning verbs!" id="sKk-nD-wyF">
                         <barButtonItem key="rightBarButtonItem" systemItem="done" id="go0-0M-J8o">
                             <connections>
                                 <action selector="doneButtonPressed:" destination="YgC-0v-uRA" id="3ms-zZ-8sN"/>
@@ -245,7 +256,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ND8-Qk-eUf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2686.875" y="96.126760563380287"/>
+            <point key="canvasLocation" x="2685.5999999999999" y="95.802098950524751"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="CLp-gA-XVf">

--- a/BattleBump/MovesetEditor.storyboard
+++ b/BattleBump/MovesetEditor.storyboard
@@ -206,7 +206,7 @@
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                     <connections>
-                                                        <action selector="beatsTextFieldDidEndEditing:" destination="YgC-0v-uRA" eventType="editingDidEnd" id="qm7-8P-kzc"/>
+                                                        <action selector="verbTextFieldDidEndEditing:" destination="YgC-0v-uRA" eventType="editingDidEnd" id="jr7-u8-kl6"/>
                                                     </connections>
                                                 </textField>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H29-zq-Hp1">
@@ -226,6 +226,7 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="losingMoveLabel" destination="H29-zq-Hp1" id="K3W-iZ-bhK"/>
+                                            <outlet property="verbTextField" destination="tXz-qr-XDw" id="r75-Kz-vhE"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/BattleBump/MovesetViewController.swift
+++ b/BattleBump/MovesetViewController.swift
@@ -8,12 +8,16 @@
 
 import UIKit
 
-class MovesetViewController: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource {
+class MovesetViewController: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource, UITextFieldDelegate {
     
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var minusMovesButton: UIButton!
     @IBOutlet weak var plusMovesButton: UIButton!
     @IBOutlet weak var numberOfOutcomesLabel: UILabel!
+    @IBOutlet weak var moveNameLabel: UILabel!
+    @IBOutlet weak var moveEmojiLabel: UILabel!
+    @IBOutlet weak var moveNameTextField: UITextField!
+    @IBOutlet weak var moveEmojiTextField: UITextField!
     var currentNumberOfMoves: Int?
     let minimumNumberOfMoves = 3
     let maximumNumberOfMoves = 9
@@ -28,19 +32,28 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configure()
-    }
-    
-    func configure() {
-        currentNumberOfMoves = movesetInProgress.moves.count
+        moveNameTextField.delegate = self
+        moveEmojiTextField.delegate = self
+        moveNameLabel.text = "Move Name:"
+        moveEmojiLabel.text = "Move Emoji:"
         
+        currentNumberOfMoves = movesetInProgress.moves.count
         if currentNumberOfMoves == minimumNumberOfMoves {
             disableInteractionWith(button: minusMovesButton)
         }
-        
         if currentNumberOfMoves == maximumNumberOfMoves {
             disableInteractionWith(button: plusMovesButton)
         }
+        
+        moveNameTextField.isUserInteractionEnabled = false
+        moveEmojiTextField.isUserInteractionEnabled = false
+        let outcomesNum = (Float(self.movesetInProgress.moves.count) * 0.5).rounded(.down) * Float(self.movesetInProgress.moves.count)
+        numberOfOutcomesLabel.text = "\(Int(outcomesNum)) possible outcomes"
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        moveNameTextField.resignFirstResponder()
+        moveEmojiTextField.resignFirstResponder()
     }
     
     //MARK: - IBActions -
@@ -78,8 +91,58 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
         redrawViews()
     }
     
+    @IBAction func pickVerbsButtonPressed(_ sender: UIButton) {
+        self.performSegue(withIdentifier: "pickVerbs", sender: sender)
+    }
+    
+    @IBAction func cancelButtonPressed(_ sender: UIBarButtonItem) {
+        // TODO: Ask the user if they're sure they want to exit
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func doneButtonPressed(_ sender: UIBarButtonItem) {
+        // save
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func moveNameTextFieldDidEndEditing(_ sender: UITextField) {
+        guard let text = sender.text, !text.isEmpty else {
+            return
+        }
+        
+        let indexPath = collectionView.indexPathsForSelectedItems?.first
+        movesetInProgress.moves[indexPath!.item] = sender.text ?? "DefaultMove\(indexPath!.item)"
+        
+        moveNameTextField.resignFirstResponder()
+        collectionView.reloadData()
+        collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .top)
+    }
+    
+    @IBAction func moveEmojiTextFieldDidEndEditing(_ sender: UITextField) {
+        guard let text = sender.text, !text.isEmpty else {
+            return
+        }
+        
+        let indexPath = collectionView.indexPathsForSelectedItems?.first
+        let item = movesetInProgress.moves[indexPath!.item]
+        movesetInProgress.moveEmojis!.updateValue(sender.text ?? "⛔️", forKey: item)
+        
+        moveEmojiTextField.resignFirstResponder()
+        collectionView.reloadData()
+        collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .top)
+    }
+    
+    // MARK: - Helper -
+    
     func redrawViews() {
         DispatchQueue.main.async {
+            
+            self.collectionView.indexPathsForSelectedItems?.forEach({ self.collectionView.deselectItem(at: $0, animated: false) })
+            
+            if let selectedIndexes = self.collectionView.indexPathsForSelectedItems {
+                print("Index Paths currently selected: \(selectedIndexes)")
+            }
+            
             self.collectionView.reloadData()
             let outcomesNum = (Float(self.movesetInProgress.moves.count) * 0.5).rounded(.down) * Float(self.movesetInProgress.moves.count)
             self.numberOfOutcomesLabel.text = "\(Int(outcomesNum)) possible outcomes"
@@ -110,20 +173,6 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
         }
     }
     
-    @IBAction func pickVerbsButtonPressed(_ sender: UIButton) {
-        self.performSegue(withIdentifier: "pickVerbs", sender: sender)
-    }
-    
-    @IBAction func cancelButtonPressed(_ sender: UIBarButtonItem) {
-        // TODO: Ask the user if they're sure they want to exit
-        self.dismiss(animated: true, completion: nil)
-    }
-    
-    @IBAction func doneButtonPressed(_ sender: UIBarButtonItem) {
-        // save
-        self.dismiss(animated: true, completion: nil)
-    }
-    
     // MARK: - UICollectionView -
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -143,4 +192,32 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
  
     }
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if let selectedIndexes = self.collectionView.indexPathsForSelectedItems {
+            print("didSelectItem. New index paths currently selected: \(selectedIndexes)")
+        }
+        let selectedMove = movesetInProgress.moves[indexPath.item]
+        if let emoji = movesetInProgress.moveEmojis![selectedMove] {
+            DispatchQueue.main.async {
+                self.moveNameTextField.text = "\(selectedMove)"
+                self.moveEmojiTextField.text = "\(emoji)"
+                self.moveNameTextField.isUserInteractionEnabled = true
+                self.moveEmojiTextField.isUserInteractionEnabled = true
+            }
+        }
+    }
+    
+//    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+//        if let selectedIndexes = self.collectionView.indexPathsForSelectedItems {
+//            print("didDeselectItem. New index paths currently selected: \(selectedIndexes)")
+//        }
+//    }
+    
+    //MARK: - UITextFieldDelegate Methods -
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        moveNameTextField.resignFirstResponder()
+        moveEmojiTextField.resignFirstResponder()
+        return true
+    }
 }

--- a/BattleBump/MovesetViewController.swift
+++ b/BattleBump/MovesetViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MovesetViewController: UIViewController {
+class MovesetViewController: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource {
     
     @IBOutlet weak var minusMovesButton: UIButton!
     @IBOutlet weak var plusMovesButton: UIButton!
@@ -32,7 +32,7 @@ class MovesetViewController: UIViewController {
     }
     
     func configure() {
-        drawMovesetDiagram(number: movesetInProgress.movesAndVerbsDictionary!.keys.count)
+//        drawMovesetDiagram(number: movesetInProgress.movesAndVerbsDictionary!.keys.count)
         currentNumberOfMoves = movesetInProgress.movesAndVerbsDictionary!.keys.count
         
         if currentNumberOfMoves == minimumNumberOfMoves {
@@ -65,6 +65,8 @@ class MovesetViewController: UIViewController {
             default:
                 self.movesetImageView.image = UIImage(named: "2-simplex")
             }
+            
+            self.movesetImageView.alpha = 0.3
         }
         
     }
@@ -78,7 +80,7 @@ class MovesetViewController: UIViewController {
             disableInteractionWith(button: minusMovesButton)
         }
         enableInteractionWith(button: plusMovesButton)
-        drawMovesetDiagram(number: currentNumberOfMoves!)
+//        drawMovesetDiagram(number: currentNumberOfMoves!)
     }
     
     @IBAction func plus2MovesButtonPressed(_ sender: UIButton) {
@@ -88,7 +90,7 @@ class MovesetViewController: UIViewController {
             disableInteractionWith(button: plusMovesButton)
         }
         enableInteractionWith(button: minusMovesButton)
-        drawMovesetDiagram(number: currentNumberOfMoves!)
+//        drawMovesetDiagram(number: currentNumberOfMoves!)
     }
     
     func enableInteractionWith(button: UIButton) {
@@ -127,6 +129,29 @@ class MovesetViewController: UIViewController {
             print(position.x)
             print(position.y)
         }
+    }
+    
+    // MARK: - UICollectionView -
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return movesetInProgress.movesAndVerbsDictionary!.keys.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "circle", for: indexPath) as! CircularCollectionViewCell
+        //        cell.backgroundView?.backgroundColor = items[indexPath.item]
+        //        let moveKeys = Array(arrayLiteral: movesetInProgress.moveEmojis?.keys)
+        //        let sectionKey = moveKeys[indexPath.section]
+        //        let emojiSection = moveKeys[sectionKey]
+        //        let moveEmoji = emojiSection[indexPath.row]
+        let thisMove = movesetInProgress.moves[indexPath.item]
+        if let emoji = movesetInProgress.moveEmojis![thisMove] {
+            cell.circleLabel.text = "\(emoji)"
+            cell.backgroundColor = UIColor.gray
+        }
+        return cell
+        
+        
     }
     
 }

--- a/BattleBump/MovesetViewController.swift
+++ b/BattleBump/MovesetViewController.swift
@@ -10,11 +10,15 @@ import UIKit
 
 class MovesetViewController: UIViewController {
     
+    @IBOutlet weak var minusMovesButton: UIButton!
+    @IBOutlet weak var plusMovesButton: UIButton!
     @IBOutlet weak var movesetImageView: UIImageView!
     @IBOutlet weak var numberOfOutcomesLabel: UILabel!
     var currentNumberOfMoves: Int?
     let minimumNumberOfMoves = 3
     let maximumNumberOfMoves = 9
+    // TODO: allow user to pick from 'sample' movesets like "Weapon triangle": ["Sword", "Spear", "Axe"] or "Pokemon": ["Grass", "Fire", "Rock", "Psychic", "Fighting", "Flying", "Water"] or "RPSLS 🖖"
+    // TODO: emoji skin-color picker?
     
     var movesetInProgress: Moveset! {
         didSet {
@@ -24,20 +28,25 @@ class MovesetViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-                configure()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        //    configure()
+        configure()
     }
     
     func configure() {
-        drawMovesetDiagram(number: movesetInProgress.numberOfMoves)
-        currentNumberOfMoves = movesetInProgress.numberOfMoves
+        drawMovesetDiagram(number: movesetInProgress.movesAndVerbsDictionary!.keys.count)
+        currentNumberOfMoves = movesetInProgress.movesAndVerbsDictionary!.keys.count
+        
+        if currentNumberOfMoves == minimumNumberOfMoves {
+            disableInteractionWith(button: minusMovesButton)
+        }
+        
+        if currentNumberOfMoves == maximumNumberOfMoves {
+            disableInteractionWith(button: plusMovesButton)
+        }
     }
     
     func drawMovesetDiagram(number: Int) {
         
+        // Number of outcomes will always be "0.5n (rounded down) * n", maybe extract into func when 9-move cap is lifted
         switch number {
         case 3:
             movesetImageView.image = UIImage(named: "2-simplex")
@@ -62,22 +71,34 @@ class MovesetViewController: UIViewController {
     
     @IBAction func minus2MovesButtonPressed(_ sender: UIButton) {
         
-        if currentNumberOfMoves == minimumNumberOfMoves {
-            print("min move threshold reached")
-            return
-        }
         currentNumberOfMoves = currentNumberOfMoves! - 2
+        if currentNumberOfMoves == minimumNumberOfMoves {
+            disableInteractionWith(button: minusMovesButton)
+        }
+        enableInteractionWith(button: plusMovesButton)
         drawMovesetDiagram(number: currentNumberOfMoves!)
     }
     
     @IBAction func plus2MovesButtonPressed(_ sender: UIButton) {
         
-        if currentNumberOfMoves == maximumNumberOfMoves {
-            print("max move threshold reached")
-            return
-        }
         currentNumberOfMoves = currentNumberOfMoves! + 2
+        if currentNumberOfMoves == maximumNumberOfMoves {
+            disableInteractionWith(button: plusMovesButton)
+        }
+        enableInteractionWith(button: minusMovesButton)
         drawMovesetDiagram(number: currentNumberOfMoves!)
+    }
+    
+    func enableInteractionWith(button: UIButton) {
+        button.isUserInteractionEnabled = true
+        button.alpha = 1.0
+        button.setTitleColor(.systemBlue, for: .normal)
+    }
+    
+    func disableInteractionWith(button: UIButton) {
+        button.isUserInteractionEnabled = false
+        button.alpha = 0.5
+        button.setTitleColor(.gray, for: .normal)
     }
     
     @IBAction func pickVerbsButtonPressed(_ sender: UIButton) {
@@ -85,6 +106,7 @@ class MovesetViewController: UIViewController {
     }
     
     @IBAction func cancelButtonPressed(_ sender: UIBarButtonItem) {
+        // TODO: Ask the user if they're sure they want to exit
         self.dismiss(animated: true, completion: nil)
     }
     

--- a/BattleBump/MovesetViewController.swift
+++ b/BattleBump/MovesetViewController.swift
@@ -69,11 +69,7 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
         }
         enableInteractionWith(button: plusMovesButton)
         
-//        let last2Moves = Array(movesetInProgress.moveArray.suffix(2))
         movesetInProgress.moveArray.removeLast(2)
-//        movesetInProgress.moveEmojis?.removeValue(forKey: last2Moves[0])
-//        movesetInProgress.moveEmojis?.removeValue(forKey: last2Moves[1])
-        
         moveArrayCountHalved = Int(round(Double(movesetInProgress.moveArray.count/2)))
         redrawViews()
     }
@@ -86,15 +82,8 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
         }
         enableInteractionWith(button: minusMovesButton)
         
-//        let currentMovesCount = movesetInProgress.moveArray.count
-//        movesetInProgress.moves.append("DefaultMove\(currentMovesCount+1)")
-//        movesetInProgress.moves.append("DefaultMove\(currentMovesCount+2)")
-//        movesetInProgress.moveEmojis!["DefaultMove\(currentMovesCount+1)"] = randomEmoji()
-//        movesetInProgress.moveEmojis!["DefaultMove\(currentMovesCount+2)"] = randomEmoji()
         let defaultMove = Move(moveName: "Default Move", moveEmoji: "❓", moveVerbs: ["vsDefault":"beats"])
-//        movesetInProgress.moveArray.append(defaultMove)
         movesetInProgress.moveArray.append(contentsOf: repeatElement(defaultMove, count: 2))
-        
         moveArrayCountHalved = Int(round(Double(movesetInProgress.moveArray.count/2)))
         redrawViews()
     }
@@ -152,15 +141,15 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
     // MARK: - Helper -
     
     func redrawViews() {
-            self.collectionView.indexPathsForSelectedItems?.forEach({ self.collectionView.deselectItem(at: $0, animated: false) })
-            
-            if let selectedIndexes = self.collectionView.indexPathsForSelectedItems {
-                print("Index Paths currently selected: \(selectedIndexes)")
+        self.collectionView.indexPathsForSelectedItems?.forEach({ self.collectionView.deselectItem(at: $0, animated: false) })
+        collectionView.layer.sublayers?.forEach { layer in
+            if layer.name == "line" {
+                layer.removeFromSuperlayer()
             }
-            
-            self.collectionView.reloadData()
-            let outcomesNum = (Float(self.movesetInProgress.moveArray.count) * 0.5).rounded(.down) * Float(self.movesetInProgress.moveArray.count)
-            self.numberOfOutcomesLabel.text = "\(Int(outcomesNum)) possible outcomes"
+        }
+        self.collectionView.reloadData()
+        let outcomesNum = (Float(self.movesetInProgress.moveArray.count) * 0.5).rounded(.down) * Float(self.movesetInProgress.moveArray.count)
+        self.numberOfOutcomesLabel.text = "\(Int(outcomesNum)) possible outcomes"
     }
     
 //    func randomEmoji() -> String {
@@ -172,15 +161,15 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
 //    }
     
     func enableInteractionWith(button: UIButton) {
-            button.isUserInteractionEnabled = true
-            button.alpha = 1.0
-            button.setTitleColor(.systemBlue, for: .normal)
+        button.isUserInteractionEnabled = true
+        button.alpha = 1.0
+        button.setTitleColor(.systemBlue, for: .normal)
     }
     
     func disableInteractionWith(button: UIButton) {
-            button.isUserInteractionEnabled = false
-            button.alpha = 0.5
-            button.setTitleColor(.gray, for: .normal)
+        button.isUserInteractionEnabled = false
+        button.alpha = 0.5
+        button.setTitleColor(.gray, for: .normal)
     }
     
     // MARK: - UICollectionView -
@@ -191,16 +180,13 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "circle", for: indexPath) as! CircularCollectionViewCell
-        //        let thisMove = movesetInProgress.moveArray[indexPath.item].moveEmoji
-        //        if let emoji = movesetInProgress.moveEmojis![thisMove]
         let emoji = movesetInProgress.moveArray[indexPath.item].moveEmoji
         cell.circleLabel.text = emoji
         cell.layer.borderWidth = 1
         cell.layer.borderColor = UIColor.systemBlue.cgColor
-        cell.layer.cornerRadius = 10.0
-        
+        cell.layer.cornerRadius = 15.0
+        cell.layer.backgroundColor = UIColor.systemBackground.cgColor
         return cell
-        
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -208,8 +194,15 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
         guard let selectedCell = collectionView.cellForItem(at: indexPath) else {
             return
         }
+        
+        collectionView.layer.sublayers?.forEach { layer in
+            if layer.name == "line" {
+                layer.removeFromSuperlayer()
+            }
+        }
+        
         selectedCell.layer.borderColor = UIColor.systemBlue.cgColor
-        selectedCell.layer.borderWidth = 4
+        selectedCell.layer.borderWidth = 6
         let selectedMove = movesetInProgress.moveArray[indexPath.item]
         moveNameTextField.text = selectedMove.moveName
         moveEmojiTextField.text = selectedMove.moveEmoji
@@ -227,36 +220,31 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
         print("losesAgainstIndexes: \(losesAgainstIndexes)") // [4, 5, 6]
         print("winsAgainstIndexes: \(winsAgainstIndexes)") // [2, 1, 0]
         
-        var losesAgainstCells = [UICollectionViewCell]()
         losesAgainstIndexes.forEach { index in
-            let indexpath = IndexPath(indexes: [0,index])
-            let cell = collectionView.cellForItem(at: indexpath)
-            losesAgainstCells.append(cell!)
-        }
-        losesAgainstCells.forEach { cell in
-            cell.layer.borderColor = UIColor.systemRed.cgColor
-            cell.layer.borderWidth = 4
-            // TODO: draw arrows or other UI element TO selected cell FROM other cells that BEAT selected cell
+            if let cell = collectionView.cellForItem(at: IndexPath(indexes: [0,index])) {
+                cell.layer.borderColor = UIColor.systemRed.cgColor
+                cell.layer.borderWidth = 3
+                // TODO: draw arrows or other UI element TO selected cell FROM other cells that BEAT selected cell
+                collectionView.drawLineFrom(from: IndexPath(indexes: [0,index]), to: indexPath, color: UIColor.systemRed)
+            }
         }
         
-        var winsAgainstCells = [UICollectionViewCell]()
         winsAgainstIndexes.forEach { index in
-            let indexpath = IndexPath(indexes: [0,index])
-            let cell = collectionView.cellForItem(at: indexpath)
-            winsAgainstCells.append(cell!)
-        }
-        winsAgainstCells.forEach { cell in
-            cell.layer.borderColor = UIColor.systemGreen.cgColor
-            cell.layer.borderWidth = 4
-            // draw arrows or other UI element FROM selected cell TO other cells that are BEATEN by selected cell
+            if let cell = collectionView.cellForItem(at: IndexPath(indexes: [0,index])) {
+                cell.layer.borderColor = UIColor.systemGreen.cgColor
+                cell.layer.borderWidth = 3
+                // TODO: draw arrows or other UI element FROM selected cell TO other cells that are BEATEN by selected cell
+                collectionView.drawLineFrom(from: IndexPath(indexes: [0,index]), to: indexPath, color: UIColor.systemGreen)
+                
+            }
         }
     }
     
-//    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-//        if let selectedIndexes = self.collectionView.indexPathsForSelectedItems {
-//            print("didDeselectItem. New index paths currently selected: \(selectedIndexes)")
-//        }
-//    }
+    //    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+    //        if let selectedIndexes = self.collectionView.indexPathsForSelectedItems {
+    //            print("didDeselectItem. New index paths currently selected: \(selectedIndexes)")
+    //        }
+    //    }
     
     //MARK: - UITextFieldDelegate Methods -
     
@@ -271,5 +259,37 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
 extension Array {
     subscript (wrapping index: Int) -> Element {
         return self[(index % self.count + self.count) % self.count]
+    }
+}
+
+//https://stackoverflow.com/questions/39396778/uicollectionview-draw-a-line-between-cells/39397325#39397325
+extension UICollectionView {
+    func drawLineFrom(
+        from: IndexPath,
+        to: IndexPath,
+        lineWidth: CGFloat = 2,
+        color: UIColor = UIColor.systemBlue
+    ) {
+        guard
+            let fromPoint = cellForItem(at: from)?.center,
+            let toPoint = cellForItem(at: to)?.center
+        else {
+            return
+        }
+        
+        let path = UIBezierPath()
+        
+        path.move(to: convert(fromPoint, to: self))
+        path.addLine(to: convert(toPoint, to: self))
+        
+        let layer = CAShapeLayer()
+        
+        layer.path = path.cgPath
+        layer.lineWidth = lineWidth
+        layer.strokeColor = color.cgColor
+        layer.name = "line"
+        layer.zPosition = -500
+        layer.lineDashPattern = [15, 5]
+        self.layer.addSublayer(layer)
     }
 }

--- a/BattleBump/MovesetViewController.swift
+++ b/BattleBump/MovesetViewController.swift
@@ -22,7 +22,7 @@ class MovesetViewController: UIViewController {
     
     var movesetInProgress: Moveset! {
         didSet {
-//            configure()
+            // make a copy for 'Undo All Changes'?
         }
     }
     
@@ -46,23 +46,25 @@ class MovesetViewController: UIViewController {
     
     func drawMovesetDiagram(number: Int) {
         
-        // Number of outcomes will always be "0.5n (rounded down) * n", maybe extract into func when 9-move cap is lifted
-        switch number {
-        case 3:
-            movesetImageView.image = UIImage(named: "2-simplex")
-            numberOfOutcomesLabel.text = "3 possible outcomes 🙂"
-        case 5:
-            movesetImageView.image = UIImage(named: "4-simplex")
-            numberOfOutcomesLabel.text = "10 possible outcomes 🤔"
-        case 7:
-            movesetImageView.image = UIImage(named: "6-simplex")
-            numberOfOutcomesLabel.text = "21 possible outcomes 😥"
-        case 9:
-            movesetImageView.image = UIImage(named: "8-simplex")
-            numberOfOutcomesLabel.text = "36 possible outcomes 😳"
-            
-        default:
-            movesetImageView.image = UIImage(named: "2-simplex")
+        DispatchQueue.main.async() {
+            // Number of outcomes will always be "0.5n (rounded down) * n", maybe extract into func when 9-move cap is lifted
+            switch number {
+            case 3:
+                self.movesetImageView.image = UIImage(named: "2-simplex")
+                self.numberOfOutcomesLabel.text = "3 possible outcomes 🙂"
+            case 5:
+                self.movesetImageView.image = UIImage(named: "4-simplex")
+                self.numberOfOutcomesLabel.text = "10 possible outcomes 🤔"
+            case 7:
+                self.movesetImageView.image = UIImage(named: "6-simplex")
+                self.numberOfOutcomesLabel.text = "21 possible outcomes 😥"
+            case 9:
+                self.movesetImageView.image = UIImage(named: "8-simplex")
+                self.numberOfOutcomesLabel.text = "36 possible outcomes 😳"
+                
+            default:
+                self.movesetImageView.image = UIImage(named: "2-simplex")
+            }
         }
         
     }
@@ -90,15 +92,19 @@ class MovesetViewController: UIViewController {
     }
     
     func enableInteractionWith(button: UIButton) {
-        button.isUserInteractionEnabled = true
-        button.alpha = 1.0
-        button.setTitleColor(.systemBlue, for: .normal)
+        DispatchQueue.main.async() {
+            button.isUserInteractionEnabled = true
+            button.alpha = 1.0
+            button.setTitleColor(.systemBlue, for: .normal)
+        }
     }
     
     func disableInteractionWith(button: UIButton) {
-        button.isUserInteractionEnabled = false
-        button.alpha = 0.5
-        button.setTitleColor(.gray, for: .normal)
+        DispatchQueue.main.async() {
+            button.isUserInteractionEnabled = false
+            button.alpha = 0.5
+            button.setTitleColor(.gray, for: .normal)
+        }
     }
     
     @IBAction func pickVerbsButtonPressed(_ sender: UIButton) {

--- a/BattleBump/MovesetViewController.swift
+++ b/BattleBump/MovesetViewController.swift
@@ -156,14 +156,14 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
     // MARK: - Helper -
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "pickVerbs", let editVerbsVC = segue.destination as? EditVerbsViewController {
+        if segue.identifier == "pickVerbs" {
             
             if movesetInProgress.moveArray.contains(where:{ $0.moveName.contains("Default") }) {
                 // prompt the user to update default moves before segue
                 return
             }
-            //            let destinationNavigationController = segue.destination as! UINavigationController
-            //            let editVerbsController = destinationNavigationController.topViewController as! EditVerbsViewController
+            let destinationNavigationController = segue.destination as! UINavigationController
+            let editVerbsVC = destinationNavigationController.topViewController as! EditVerbsViewController
             editVerbsVC.movesetInProgress = movesetInProgress
             editVerbsVC.onFinishEditingVerbs = { [weak self] movesetInProgress in
                 guard let self = self else {

--- a/BattleBump/MovesetViewController.swift
+++ b/BattleBump/MovesetViewController.swift
@@ -97,7 +97,6 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
     }
     
     @IBAction func cancelButtonPressed(_ sender: UIBarButtonItem) {
-        // TODO: Ask the user if they're sure they want to exit
         let alertController = UIAlertController(title: "Are you sure?", message: nil, preferredStyle: .alert)
         let alertAction = UIAlertAction(title: "OK", style: .default, handler: {_ in
             self.movesetInProgress = self.initialMoveset
@@ -156,6 +155,25 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
     
     // MARK: - Helper -
     
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "pickVerbs", let editVerbsVC = segue.destination as? EditVerbsViewController {
+            
+            if movesetInProgress.moveArray.contains(where:{ $0.moveName.contains("Default") }) {
+                // prompt the user to update default moves before segue
+                return
+            }
+            //            let destinationNavigationController = segue.destination as! UINavigationController
+            //            let editVerbsController = destinationNavigationController.topViewController as! EditVerbsViewController
+            editVerbsVC.movesetInProgress = movesetInProgress
+            editVerbsVC.onFinishEditingVerbs = { [weak self] movesetInProgress in
+                guard let self = self else {
+                    return
+                }
+                self.movesetInProgress = movesetInProgress
+            }
+        }
+    }
+    
     func redrawViews() {
         self.collectionView.indexPathsForSelectedItems?.forEach({ self.collectionView.deselectItem(at: $0, animated: false) })
         collectionView.layer.sublayers?.forEach { layer in
@@ -168,13 +186,13 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
         self.numberOfOutcomesLabel.text = "\(Int(outcomesNum)) possible outcomes"
     }
     
-//    func randomEmoji() -> String {
-//        let range = 0x1F300...0x1F3F0
-//        let index = Int(arc4random_uniform(UInt32(range.count)))
-//        let ord = range.lowerBound + index
-//        guard let scalar = UnicodeScalar(ord) else { return "❓" }
-//        return String(scalar)
-//    }
+    //    func randomEmoji() -> String {
+    //        let range = 0x1F300...0x1F3F0
+    //        let index = Int(arc4random_uniform(UInt32(range.count)))
+    //        let ord = range.lowerBound + index
+    //        guard let scalar = UnicodeScalar(ord) else { return "❓" }
+    //        return String(scalar)
+    //    }
     
     func enableInteractionWith(button: UIButton) {
         button.isUserInteractionEnabled = true
@@ -271,7 +289,7 @@ class MovesetViewController: UIViewController, UICollectionViewDelegate, UIColle
     }
 }
 
-    // MARK: - Extensions -
+// MARK: - Extensions -
 //https://stackoverflow.com/questions/45397603/cleanest-way-to-wrap-array-index
 extension Array {
     subscript (wrapping index: Int) -> Element {

--- a/BattleBump/Player.swift
+++ b/BattleBump/Player.swift
@@ -11,11 +11,11 @@ import UIKit
 class Player: Codable {
     
     var name: String
-    var selectedMove: String? // TODO: change to use Moveset.swift and/or Move object etc
+    var selectedMove: String?
+    //var selectedMove: Move?
     var isReadyForNewRound: Bool
     var isHost: Bool
-//    var chosenMoveset: Moveset
-//    var playerImage
+    var chosenMoveset: Moveset?
     
     init(name: String) {
         self.name = name

--- a/BattleBump/Player.swift
+++ b/BattleBump/Player.swift
@@ -11,11 +11,10 @@ import UIKit
 class Player: Codable {
     
     var name: String
-    var selectedMove: String?
-    //var selectedMove: Move?
     var isReadyForNewRound: Bool
     var isHost: Bool
     var chosenMoveset: Moveset?
+    var selectedMove: Move?
     
     init(name: String) {
         self.name = name

--- a/BattleBump/VerbEditCell.swift
+++ b/BattleBump/VerbEditCell.swift
@@ -12,9 +12,11 @@ class VerbEditCell: UITableViewCell {
     
     @IBOutlet weak var verbTextField: UITextField!
     @IBOutlet weak var losingMoveLabel: UILabel!
+    var cellMove: Move?
     
-    public func configure(losingMoveName: String, verb: String) {
-        losingMoveLabel.text = losingMoveName
+    public func configure(losingMove: Move, verb: String) {
+        cellMove = losingMove
+        losingMoveLabel.text = "\(losingMove.moveEmoji) \(losingMove.moveName)"
         verbTextField.text = verb
     }
     

--- a/BattleBump/VerbEditCell.swift
+++ b/BattleBump/VerbEditCell.swift
@@ -1,0 +1,22 @@
+//
+//  VerbEditCell.swift
+//  BattleBump
+//
+//  Created by Callum Davies on 2020-11-11.
+//  Copyright © 2020 Callum Davies & Dave Augerinos. All rights reserved.
+//
+
+import UIKit
+
+class VerbEditCell: UITableViewCell {
+    
+    @IBOutlet weak var verbTextField: UITextField!
+    @IBOutlet weak var losingMoveLabel: UILabel!
+    
+    var move: Move! {
+        didSet {
+            losingMoveLabel.text = move.moveName
+        }
+    }
+    
+}

--- a/BattleBump/VerbEditCell.swift
+++ b/BattleBump/VerbEditCell.swift
@@ -13,10 +13,9 @@ class VerbEditCell: UITableViewCell {
     @IBOutlet weak var verbTextField: UITextField!
     @IBOutlet weak var losingMoveLabel: UILabel!
     
-    var move: Move! {
-        didSet {
-            losingMoveLabel.text = move.moveName
-        }
+    public func configure(losingMoveName: String, verb: String) {
+        losingMoveLabel.text = losingMoveName
+        verbTextField.text = verb
     }
     
 }


### PR DESCRIPTION
This PR:
- Allows users to edit a custom moveset and pick the winning verbs.
- Allows users to play with the host player's chosen custom moveset (the second player doesn't need to have the host's moveset before playing).

<img width="827" alt="Screen Shot 2020-11-16 at 9 31 02 AM" src="https://user-images.githubusercontent.com/18037150/99286957-798e4a00-27ee-11eb-96e5-31438165fc88.png">

<img width="905" alt="Screen Shot 2020-11-14 at 10 28 50 PM" src="https://user-images.githubusercontent.com/18037150/99194310-84d06f80-2733-11eb-82ff-d4667850dc4f.png">

Very much an 'MVP' at the moment, more nice-to-have features planned.